### PR TITLE
Updated names for consistency

### DIFF
--- a/custom_components/sleepme_thermostat/binary_sensor.py
+++ b/custom_components/sleepme_thermostat/binary_sensor.py
@@ -42,7 +42,7 @@ class WaterLevelLowSensor(BinarySensorEntity):
         # Fetch device info from the thermostat entity
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device_id)},
-            "name": f"SleepMe {name}",
+            "name": f"Dock Pro {name}",
             "manufacturer": "SleepMe",
             "model": thermostat._model,
             "sw_version": thermostat._firmware_version,

--- a/custom_components/sleepme_thermostat/climate.py
+++ b/custom_components/sleepme_thermostat/climate.py
@@ -27,7 +27,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class SleepMeThermostat(ClimateEntity):
     def __init__(self, controller, device_id, name, device_info):
         self._controller = controller
-        self._name = f"SleepMe {name}"
+        self._name = f"Dock Pro {name}"
         self._device_id = device_id
         self._target_temperature = None
         self._hvac_mode = HVACMode.OFF

--- a/custom_components/sleepme_thermostat/config_flow.py
+++ b/custom_components/sleepme_thermostat/config_flow.py
@@ -90,7 +90,7 @@ class SleepMeThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 # Store device info in the entry data
                 return self.async_create_entry(
-                    title=f"SleepMe {name}",
+                    title=f"Dock Pro {name}",
                     data={
                         "api_url": API_URL,
                         "api_token": self.context["api_token"],

--- a/custom_components/sleepme_thermostat/translations/es.json
+++ b/custom_components/sleepme_thermostat/translations/es.json
@@ -1,9 +1,9 @@
 {
-  "title": "SleepMe Dock PRO",
+  "title": "SleepMe Dock Pro",
   "config": {
     "step": {
       "user": {
-        "title": "Configurar SleepMe Dock PRO",
+        "title": "Configurar SleepMe Dock Pro",
         "description": "Por favor, ingrese su token de API.",
         "data": {
           "api_token": "Token de API"
@@ -11,7 +11,7 @@
       },
       "select_device": {
         "title": "Seleccionar Dispositivo",
-        "description": "Seleccione el dispositivo Dock PRO que desea configurar.",
+        "description": "Seleccione el dispositivo Dock Pro que desea configurar.",
         "data": {
           "device_id": "ID del Dispositivo"
         }


### PR DESCRIPTION
Changed default device name from SleepMe {name} to Dock Pro {name}
Changed Spanish configuration title from PRO to Pro so it is more consistent with other nomenclature