### PR TITLE
Support Max Heat and Max Cool as preset modes

### DIFF
--- a/custom_components/sleepme_thermostat/climate.py
+++ b/custom_components/sleepme_thermostat/climate.py
@@ -134,6 +134,9 @@ class SleepMeThermostat(CoordinatorEntity, ClimateEntity):
         self.async_write_ha_state()
 
     async def async_set_preset_mode(self, preset_mode):
+        # If device is off and trying to set a preset other than PRESET_NONE, turn it on first
+        if self.hvac_mode == HVACMode.OFF and preset_mode != PRESET_NONE:
+            await self.async_set_hvac_mode(HVACMode.AUTO)
         if preset_mode in PRESET_TEMPERATURES:
             # Save the old target temperature to restore when changing to PRESET_NONE
             if self.target_temperature is not None:

--- a/custom_components/sleepme_thermostat/climate.py
+++ b/custom_components/sleepme_thermostat/climate.py
@@ -29,7 +29,7 @@ class SleepMeThermostat(CoordinatorEntity, ClimateEntity):
         self._name = f"Dock Pro {name}"
         self._device_id = device_id
         self._attr_unique_id = f"{DOMAIN}_{device_id}_thermostat"
-        self._previous_previous_target_temperature = None
+        self._previous_target_temperature = None
 
         # Set up device info attributes
         self._attr_device_info = {

--- a/custom_components/sleepme_thermostat/const.py
+++ b/custom_components/sleepme_thermostat/const.py
@@ -7,3 +7,11 @@ DEFAULT_API_HEADERS = {
 API_URL = APP_API_URL  # Optional: Alias for APP_API_URL for consistency
 
 DOMAIN = "sleepme_thermostat"
+
+PRESET_MAX_COOL = 'Max Cool'
+PRESET_MAX_HEAT = 'Max Heat'
+
+PRESET_TEMPERATURES = {
+    PRESET_MAX_COOL: -1,
+    PRESET_MAX_HEAT: 999
+}


### PR DESCRIPTION
The Dock Pro has two magic setpoints, "Max Cool" and "Max Heat."  Max Heat appears to heat more quickly than just setting the temperature to the maximum normal value, and is used for their "warm awake" feature.  I like that feature, and would like to replicate it with smarter scheduling from HA.

This PR adds support for those two setpoints as preset modes.  I try to save the previous setpoint to restore it when the preset mode is switched back to "none", defaulting to holding the current temperature if that's not possible.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for preset temperature modes, allowing users to quickly switch to options like maximum heat or maximum cool.
	- Enhanced thermostat controls now preserve and restore temperature settings when toggling between preset modes.
	- Introduced new preset modes: `PRESET_NONE`, `PRESET_MAX_HEAT`, and `PRESET_MAX_COOL`.
	- New constants for preset modes have been defined, mapping to specific temperature values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->