### PR TITLE
Fix blocking call warning

### DIFF
--- a/custom_components/sleepme_thermostat/__init__.py
+++ b/custom_components/sleepme_thermostat/__init__.py
@@ -40,7 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return False
 
     # Initialize the SleepMe client and store it in hass.data for shared access
-    sleepme_controller = SleepMeClient(api_url, api_token, device_id)
+    sleepme_controller = SleepMeClient(hass, api_url, api_token, device_id)
     hass.data[DOMAIN]["sleepme_controller"] = sleepme_controller
 
     # Create and store the update manager

--- a/custom_components/sleepme_thermostat/sleepme.py
+++ b/custom_components/sleepme_thermostat/sleepme.py
@@ -1,5 +1,6 @@
 import logging
 from .sleepme_api import SleepMeAPI
+from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -8,11 +9,11 @@ def round_half_up(n):
     return round(n * 2) / 2
 
 class SleepMeClient:
-    def __init__(self, api_url: str, token: str, device_id: str = None):
+    def __init__(self, hass: HomeAssistant, api_url: str, token: str, device_id: str = None):
         self.api_url = api_url
         self.token = token
         self.device_id = device_id
-        self.api = SleepMeAPI(api_url, token)
+        self.api = SleepMeAPI(hass, api_url, token)
         _LOGGER.debug(f"[Device {self.device_id}] Initialized SleepMeClient with API URL: {self.api_url}")
 
     async def set_temp_level(self, temp_c: float, retries: int = 2):

--- a/custom_components/sleepme_thermostat/sleepme_api.py
+++ b/custom_components/sleepme_thermostat/sleepme_api.py
@@ -2,15 +2,17 @@ import asyncio
 import httpx
 import logging
 import time
+from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.core import HomeAssistant
 from collections import deque
 
 _LOGGER = logging.getLogger(__name__)
 
 class SleepMeAPI:
-    def __init__(self, api_url: str, token: str, max_requests_per_minute=9):
+    def __init__(self, hass: HomeAssistant, api_url: str, token: str, max_requests_per_minute=9):
         self.api_url = api_url
         self.token = token
-        self.client = httpx.AsyncClient()
+        self.client = get_async_client(hass)
         self.request_times = deque(maxlen=max_requests_per_minute)
         self.rate_limit_interval = 60  # seconds
 

--- a/custom_components/sleepme_thermostat/update_manager.py
+++ b/custom_components/sleepme_thermostat/update_manager.py
@@ -10,7 +10,7 @@ class SleepMeUpdateManager(DataUpdateCoordinator):
     """Manages data updates for SleepMe devices."""
 
     def __init__(self, hass: HomeAssistant, api_url: str, token: str, device_id: str):
-        self.client = SleepMeClient(api_url, token, device_id)
+        self.client = SleepMeClient(hass, api_url, token, device_id)
         self.device_id = device_id
 
         # Initialize the last known good status as None


### PR DESCRIPTION
This resolves [blocking call warnings](https://developers.home-assistant.io/docs/asyncio_blocking_operations/#load_default_certs) by switching the httpx client to the homeassisant helper.


```
2025-03-21 22:57:18.641 WARNING (MainThread) [homeassistant.util.loop] Detected blocking call to load_verify_locations with args (<ssl.SSLContext object at 0x7f65a20f80>, '/usr/local/lib/python3.13/site-packages/certifi/cacert.pem', None, None) inside the event loop by custom integration 'sleepme_thermostat' at custom_components/sleepme_thermostat/sleepme_api.py, line 13: self.client = httpx.AsyncClient() (offender: /usr/local/lib/python3.13/ssl.py, line 717: context.load_verify_locations(cafile, capath, cadata)), please create a bug report at https://github.com/rsampayo/sleepme_thermostat/issues
For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#load_verify_locations
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 227, in <module>
    sys.exit(main())
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 213, in main
    exit_code = runner.run(runtime_conf)
  File "/usr/src/homeassistant/homeassistant/runner.py", line 154, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 712, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 683, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 2040, in _run_once
    handle._run()
  File "/usr/local/lib/python3.13/asyncio/events.py", line 89, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/src/homeassistant/homeassistant/setup.py", line 171, in async_setup_component
    result = await _async_setup_component(hass, domain, config)
  File "/usr/src/homeassistant/homeassistant/setup.py", line 467, in _async_setup_component
    await asyncio.gather(
  File "/usr/src/homeassistant/homeassistant/setup.py", line 469, in <genexpr>
    create_eager_task(
  File "/usr/src/homeassistant/homeassistant/util/async_.py", line 45, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 898, in async_setup_locked
    await self.async_setup(hass, integration=integration)
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 664, in async_setup
    await self.__async_setup_with_context(hass, integration)
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 753, in __async_setup_with_context
    result = await component.async_setup_entry(hass, self)
  File "/config/custom_components/sleepme_thermostat/__init__.py", line 43, in async_setup_entry
    sleepme_controller = SleepMeClient(api_url, api_token, device_id)
  File "/config/custom_components/sleepme_thermostat/sleepme.py", line 15, in __init__
    self.api = SleepMeAPI(api_url, token)
  File "/config/custom_components/sleepme_thermostat/sleepme_api.py", line 13, in __init__
    self.client = httpx.AsyncClient()

```