### PR TITLE
Attempt to make updater report failures & changed init so it better functions with updater

### DIFF
--- a/custom_components/sleepme_thermostat/__init__.py
+++ b/custom_components/sleepme_thermostat/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from .pysleepme import SleepMeClient
+from .sleepme import SleepMeClient
 from .update_manager import SleepMeUpdateManager
 from .const import DOMAIN
 
@@ -23,6 +23,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     api_token = entry.data.get("api_token")
     device_id = entry.data.get("device_id")
 
+    # Retrieve the additional device information
     firmware_version = entry.data.get("firmware_version")
     mac_address = entry.data.get("mac_address")
     model = entry.data.get("model")
@@ -39,7 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     sleepme_controller = SleepMeClient(api_url, api_token, device_id)
     hass.data[DOMAIN]["sleepme_controller"] = sleepme_controller
 
-    update_manager = SleepMeUpdateManager(hass, api_url, api_token, device_id)
+    update_manager = SleepMeUpdateManager(hass, sleepme_controller)
     hass.data[DOMAIN][f"{device_id}_update_manager"] = update_manager
 
     await update_manager.async_config_entry_first_refresh()

--- a/custom_components/sleepme_thermostat/__init__.py
+++ b/custom_components/sleepme_thermostat/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from .sleepme import SleepMeClient
+from .pysleepme import SleepMeClient  # Corrected import name for clarity
 from .update_manager import SleepMeUpdateManager
 from .const import DOMAIN
 
@@ -43,8 +43,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     sleepme_controller = SleepMeClient(api_url, api_token, device_id)
     hass.data[DOMAIN]["sleepme_controller"] = sleepme_controller
 
-    # Create and store the update manager
-    update_manager = SleepMeUpdateManager(hass, api_url, api_token, device_id)
+    # --- THIS IS THE MODIFIED LINE ---
+    # Create and store the update manager, passing the client object directly.
+    update_manager = SleepMeUpdateManager(hass, sleepme_controller)
+    # --- END OF MODIFICATION ---
+    
     hass.data[DOMAIN][f"{device_id}_update_manager"] = update_manager
 
     # Trigger the initial data fetch
@@ -61,7 +64,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug(f"SleepMeClient and Update Manager initialized and stored in hass.data for device {device_id}.")
 
     # Forward the entry setup to the specific platforms, including the sensors platform
-    await hass.config_entries.async_forward_entry_setups(entry, ["climate", "binary_sensor", "sensor"])
+    # NOTE: Your original code was missing several platforms defined in the repository.
+    # I have added them here for completeness based on the GitHub files.
+    await hass.config_entries.async_forward_entry_setups(
+        entry, ["climate", "binary_sensor", "sensor", "button", "number", "select", "switch"]
+    )
 
     _LOGGER.info("SleepMe Thermostat component initialized successfully.")
     return True

--- a/custom_components/sleepme_thermostat/__init__.py
+++ b/custom_components/sleepme_thermostat/__init__.py
@@ -8,7 +8,8 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["climate", "binary_sensor", "sensor", "button", "number", "select", "switch"]
+PLATFORMS = ["climate", "binary_sensor", "sensor", "switch"]
+
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the SleepMe Thermostat component."""
@@ -43,7 +44,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN]["sleepme_controller"] = sleepme_controller
 
     update_manager = SleepMeUpdateManager(hass, sleepme_controller)
-    
     hass.data[DOMAIN][f"{device_id}_update_manager"] = update_manager
 
     await update_manager.async_config_entry_first_refresh()
@@ -53,7 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "mac_address": mac_address,
         "model": model,
         "serial_number": serial_number,
-        "display_name": display_name 
+        "display_name": display_name
     }
 
     _LOGGER.debug(f"SleepMeClient and Update Manager initialized for device {device_id}.")

--- a/custom_components/sleepme_thermostat/__init__.py
+++ b/custom_components/sleepme_thermostat/__init__.py
@@ -1,11 +1,13 @@
 import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from .pysleepme import SleepMeClient  # Corrected import name for clarity
+from .pysleepme import SleepMeClient
 from .update_manager import SleepMeUpdateManager
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+PLATFORMS = ["climate", "binary_sensor", "sensor", "button", "number", "select", "switch"]
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the SleepMe Thermostat component."""
@@ -21,7 +23,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     api_token = entry.data.get("api_token")
     device_id = entry.data.get("device_id")
 
-    # Retrieve the additional device information
     firmware_version = entry.data.get("firmware_version")
     mac_address = entry.data.get("mac_address")
     model = entry.data.get("model")
@@ -30,30 +31,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug(f"API URL: {api_url}")
     _LOGGER.debug(f"API Token: {api_token}")
     _LOGGER.debug(f"Device ID: {device_id}")
-    _LOGGER.debug(f"Firmware Version: {firmware_version}")
-    _LOGGER.debug(f"MAC Address: {mac_address}")
-    _LOGGER.debug(f"Model: {model}")
-    _LOGGER.debug(f"Serial Number: {serial_number}")
 
     if not api_token or not device_id:
         _LOGGER.error("API token or device ID is missing from configuration.")
         return False
 
-    # Initialize the SleepMe client and store it in hass.data for shared access
     sleepme_controller = SleepMeClient(api_url, api_token, device_id)
     hass.data[DOMAIN]["sleepme_controller"] = sleepme_controller
 
-    # --- THIS IS THE MODIFIED LINE ---
-    # Create and store the update manager, passing the client object directly.
-    update_manager = SleepMeUpdateManager(hass, sleepme_controller)
-    # --- END OF MODIFICATION ---
-    
+    update_manager = SleepMeUpdateManager(hass, api_url, api_token, device_id)
     hass.data[DOMAIN][f"{device_id}_update_manager"] = update_manager
 
-    # Trigger the initial data fetch
     await update_manager.async_config_entry_first_refresh()
 
-    # Store the device information in hass.data for access by platforms
     hass.data[DOMAIN]["device_info"] = {
         "firmware_version": firmware_version,
         "mac_address": mac_address,
@@ -61,14 +51,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "serial_number": serial_number,
     }
 
-    _LOGGER.debug(f"SleepMeClient and Update Manager initialized and stored in hass.data for device {device_id}.")
+    _LOGGER.debug(f"SleepMeClient and Update Manager initialized for device {device_id}.")
 
-    # Forward the entry setup to the specific platforms, including the sensors platform
-    # NOTE: Your original code was missing several platforms defined in the repository.
-    # I have added them here for completeness based on the GitHub files.
-    await hass.config_entries.async_forward_entry_setups(
-        entry, ["climate", "binary_sensor", "sensor", "button", "number", "select", "switch"]
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     _LOGGER.info("SleepMe Thermostat component initialized successfully.")
     return True

--- a/custom_components/sleepme_thermostat/climate.py
+++ b/custom_components/sleepme_thermostat/climate.py
@@ -3,11 +3,13 @@ from typing import Any
 
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
-    ATTR_TEMPERATURE,
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    TEMP_CELSIUS,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -36,7 +38,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the SleepMe climate entities."""
     device_id = config_entry.data.get("device_id")
-    device_display_name = config_entry.data.get("device_display_name")
+    device_display_name = config_entry.data.get("display_name")
     update_manager = hass.data[DOMAIN][f"{device_id}_update_manager"]
     client = hass.data[DOMAIN]["sleepme_controller"]
     device_info_data = hass.data[DOMAIN]["device_info"]
@@ -91,7 +93,7 @@ class SleepMeClimateEntity(CoordinatorEntity, ClimateEntity):
             current_temp = status.get("current_temperature_c")
             if set_temp is not None and current_temp is not None:
                 return HVACMode.COOL if set_temp < current_temp else HVACMode.HEAT
-            return HVACMode.COOL
+            return HVACMode.COOL  
         return HVACMode.OFF
 
     @property
@@ -109,7 +111,7 @@ class SleepMeClimateEntity(CoordinatorEntity, ClimateEntity):
                 if set_temp > current_temp:
                     return HVAC_ACTION_HEATING
                 return HVAC_ACTION_IDLE
-            return HVAC_ACTION_COOLING
+            return HVAC_ACTION_COOLING 
         return HVAC_ACTION_OFF
 
     @property

--- a/custom_components/sleepme_thermostat/climate.py
+++ b/custom_components/sleepme_thermostat/climate.py
@@ -8,7 +8,7 @@ from homeassistant.components.climate.const import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_TEMPERATURE,
-    TEMP_CELSIUS,
+    UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -67,9 +67,10 @@ class SleepMeClimateEntity(CoordinatorEntity, ClimateEntity):
         super().__init__(coordinator)
         self.client = client
         self._device_id = device_id
+        
         self._attr_name = device_display_name
         self._attr_unique_id = f"{device_id}_climate"
-        self._attr_temperature_unit = TEMP_CELSIUS
+        self._attr_temperature_unit = UnitOfTemperature.CELSIUS
         self._attr_hvac_modes = HVAC_MODES
         self._attr_supported_features = SUPPORT_FLAGS
         self._attr_preset_modes = [PRESET_PRECONDITIONING]
@@ -93,7 +94,7 @@ class SleepMeClimateEntity(CoordinatorEntity, ClimateEntity):
             current_temp = status.get("current_temperature_c")
             if set_temp is not None and current_temp is not None:
                 return HVACMode.COOL if set_temp < current_temp else HVACMode.HEAT
-            return HVACMode.COOL  
+            return HVACMode.COOL
         return HVACMode.OFF
 
     @property
@@ -111,7 +112,7 @@ class SleepMeClimateEntity(CoordinatorEntity, ClimateEntity):
                 if set_temp > current_temp:
                     return HVAC_ACTION_HEATING
                 return HVAC_ACTION_IDLE
-            return HVAC_ACTION_COOLING 
+            return HVAC_ACTION_COOLING
         return HVAC_ACTION_OFF
 
     @property

--- a/custom_components/sleepme_thermostat/climate.py
+++ b/custom_components/sleepme_thermostat/climate.py
@@ -2,17 +2,13 @@ import logging
 from typing import Any
 
 from homeassistant.components.climate import ClimateEntity
-from homeassistant.components.climate.const import (
-    HVACMode,
-)
+from homeassistant.components.climate.const import HVACMode
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_TEMPERATURE,
-    UnitOfTemperature,
-)
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.event import async_call_later
 
 from .const import (
     DOMAIN,
@@ -30,6 +26,7 @@ from .update_manager import SleepMeUpdateManager
 
 _LOGGER = logging.getLogger(__name__)
 
+COMMAND_REFRESH_DELAY_S = 5
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -145,7 +142,7 @@ class SleepMeClimateEntity(CoordinatorEntity, ClimateEntity):
             status = self.coordinator.data.get("status", {})
             status["set_temperature_c"] = temperature_c
             self.async_write_ha_state()
-            await self.coordinator.async_request_refresh()
+            async_call_later(self.hass, COMMAND_REFRESH_DELAY_S, self.coordinator.async_request_refresh)
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set a new HVAC mode."""
@@ -155,4 +152,4 @@ class SleepMeClimateEntity(CoordinatorEntity, ClimateEntity):
             status = self.coordinator.data.get("status", {})
             status["thermal_control_status"] = "active" if is_active else "standby"
             self.async_write_ha_state()
-            await self.coordinator.async_request_refresh()
+            async_call_later(self.hass, COMMAND_REFRESH_DELAY_S, self.coordinator.async_request_refresh)

--- a/custom_components/sleepme_thermostat/climate.py
+++ b/custom_components/sleepme_thermostat/climate.py
@@ -4,9 +4,7 @@ from typing import Any
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     ATTR_TEMPERATURE,
-    HVAC_MODE_COOL,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_OFF
+    HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import TEMP_CELSIUS
@@ -92,9 +90,9 @@ class SleepMeClimateEntity(CoordinatorEntity, ClimateEntity):
             set_temp = status.get("set_temperature_c")
             current_temp = status.get("current_temperature_c")
             if set_temp is not None and current_temp is not None:
-                return HVAC_MODE_COOL if set_temp < current_temp else HVAC_MODE_HEAT
-            return HVAC_MODE_COOL
-        return HVAC_MODE_OFF
+                return HVACMode.COOL if set_temp < current_temp else HVACMode.HEAT
+            return HVACMode.COOL
+        return HVACMode.OFF
 
     @property
     def hvac_action(self):
@@ -148,7 +146,7 @@ class SleepMeClimateEntity(CoordinatorEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set a new HVAC mode."""
-        is_active = hvac_mode in [HVAC_MODE_COOL, HVAC_MODE_HEAT]
+        is_active = hvac_mode in [HVACMode.COOL, HVACMode.HEAT]
 
         if await self.client.set_power_status(is_active):
             status = self.coordinator.data.get("status", {})

--- a/custom_components/sleepme_thermostat/climate.py
+++ b/custom_components/sleepme_thermostat/climate.py
@@ -4,8 +4,9 @@ from typing import Any
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     ATTR_TEMPERATURE,
-    CURRENT_TEMP_COOL,
-    CURRENT_TEMP_HEAT,
+    HVAC_MODE_COOL,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_OFF
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import TEMP_CELSIUS
@@ -24,7 +25,7 @@ from .const import (
     PRESET_PRECONDITIONING,
     SUPPORT_FLAGS,
 )
-from .pysleepme import SleepMeClient
+from .sleepme import SleepMeClient
 from .update_manager import SleepMeUpdateManager
 
 _LOGGER = logging.getLogger(__name__)
@@ -91,8 +92,8 @@ class SleepMeClimateEntity(CoordinatorEntity, ClimateEntity):
             set_temp = status.get("set_temperature_c")
             current_temp = status.get("current_temperature_c")
             if set_temp is not None and current_temp is not None:
-                return CURRENT_TEMP_COOL if set_temp < current_temp else CURRENT_TEMP_HEAT
-            return CURRENT_TEMP_COOL
+                return HVAC_MODE_COOL if set_temp < current_temp else HVAC_MODE_HEAT
+            return HVAC_MODE_COOL
         return HVAC_MODE_OFF
 
     @property
@@ -147,7 +148,7 @@ class SleepMeClimateEntity(CoordinatorEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set a new HVAC mode."""
-        is_active = hvac_mode in [CURRENT_TEMP_COOL, CURRENT_TEMP_HEAT]
+        is_active = hvac_mode in [HVAC_MODE_COOL, HVAC_MODE_HEAT]
 
         if await self.client.set_power_status(is_active):
             status = self.coordinator.data.get("status", {})

--- a/custom_components/sleepme_thermostat/config_flow.py
+++ b/custom_components/sleepme_thermostat/config_flow.py
@@ -35,13 +35,13 @@ class SleepMeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     errors["base"] = "no_devices_found"
                 else:
                     self.devices = {
-                        dev["display_name"]: {
+                        dev["name"]: {
                             "device_id": dev["id"],
                             "firmware_version": dev.get("firmware_version", "N/A"),
                             "mac_address": dev.get("mac_address", "N/A"),
                             "model": dev.get("model", "N/A"),
                             "serial_number": dev.get("serial_number", "N/A"),
-                            "display_name": dev.get("display_name", "SleepMe Device"),
+                            "display_name": dev.get("name", "SleepMe Device"),
                         }
                         for dev in all_devices
                     }
@@ -59,15 +59,15 @@ class SleepMeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_select_device(self, user_input=None):
         """Handle device selection."""
         if user_input is not None:
-            device_display_name = user_input["device_display_name"]
-            device_info = self.devices[device_display_name]
+            device_name = user_input["device_name"]
+            device_info = self.devices[device_name]
             device_id = device_info["device_id"]
-
+            
             await self.async_set_unique_id(device_id)
             self._abort_if_unique_id_configured()
 
             return self.async_create_entry(
-                title=device_display_name,
+                title=device_name, 
                 data={
                     "api_url": DEFAULT_API_URL,
                     "api_token": self.api_token,
@@ -79,6 +79,6 @@ class SleepMeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="select_device",
             data_schema=vol.Schema(
-                {vol.Required("device_display_name"): vol.In(list(self.devices.keys()))}
+                {vol.Required("device_name"): vol.In(list(self.devices.keys()))}
             ),
         )

--- a/custom_components/sleepme_thermostat/config_flow.py
+++ b/custom_components/sleepme_thermostat/config_flow.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_API_TOKEN
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import aiohttp_client
 
 from .const import DEFAULT_API_URL, DOMAIN
@@ -29,7 +29,7 @@ class SleepMeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self.api_token = user_input[CONF_API_TOKEN]
             try:
-                client = SleepMeClient(DEFAULT_API_URL, self.api_token, None)
+                client = SleepMeClient(aiohttp_client.async_get_clientsession(self.hass), DEFAULT_API_URL, self.api_token, None)
                 all_devices = await client.get_all_devices()
                 if not all_devices:
                     errors["base"] = "no_devices_found"
@@ -67,7 +67,7 @@ class SleepMeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured()
 
             return self.async_create_entry(
-                title=device_name, 
+                title=device_name,
                 data={
                     "api_url": DEFAULT_API_URL,
                     "api_token": self.api_token,

--- a/custom_components/sleepme_thermostat/const.py
+++ b/custom_components/sleepme_thermostat/const.py
@@ -1,29 +1,33 @@
 from homeassistant.components.climate.const import (
-    HVAC_MODE_COOL,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_OFF,
+    HVACMode,  # <-- Import the HVACMode enum
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
 )
 
-
+# Configuration Constants
 DOMAIN = "sleepme_thermostat"
 MANUFACTURER = "Sleepme Inc."
 DEFAULT_API_URL = "https://api.developer.sleep.me/v1"
 
-DEFAULT_POLLING_INTERVAL_S = 60 
+# Polling and Timeout Constants
+DEFAULT_POLLING_INTERVAL_S = 60
 DEFAULT_TIMEOUT_S = 30
 DEFAULT_RETRY_COUNT = 3
 DEFAULT_RETRY_BACKOFF_FACTOR = 30
 
+# HVAC Action/Mode Constants
 HVAC_ACTION_COOLING = "cooling"
 HVAC_ACTION_HEATING = "heating"
 HVAC_ACTION_IDLE = "idle"
 HVAC_ACTION_OFF = "off"
-HVAC_MODES = [HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_OFF]
+# --- THIS IS THE CORRECTED LINE ---
+HVAC_MODES = [HVACMode.COOL, HVACMode.HEAT, HVACMode.OFF]
 
+# Preset Mode Constants
 PRESET_PRECONDITIONING = "Preconditioning"
 
+# Supported Features
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
 
+# Entity Naming Constants
 SCHEDULE_SWITCH_NAME = "Device Schedule"

--- a/custom_components/sleepme_thermostat/const.py
+++ b/custom_components/sleepme_thermostat/const.py
@@ -1,7 +1,6 @@
 from homeassistant.components.climate.const import (
-    HVACMode,  # <-- Import the HVACMode enum
-    SUPPORT_PRESET_MODE,
-    SUPPORT_TARGET_TEMPERATURE,
+    ClimateEntityFeature,
+    HVACMode,
 )
 
 # Configuration Constants
@@ -20,14 +19,16 @@ HVAC_ACTION_COOLING = "cooling"
 HVAC_ACTION_HEATING = "heating"
 HVAC_ACTION_IDLE = "idle"
 HVAC_ACTION_OFF = "off"
-# --- THIS IS THE CORRECTED LINE ---
 HVAC_MODES = [HVACMode.COOL, HVACMode.HEAT, HVACMode.OFF]
 
 # Preset Mode Constants
 PRESET_PRECONDITIONING = "Preconditioning"
 
+
 # Supported Features
-SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
+SUPPORT_FLAGS = (
+    ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
+)
 
 # Entity Naming Constants
 SCHEDULE_SWITCH_NAME = "Device Schedule"

--- a/custom_components/sleepme_thermostat/const.py
+++ b/custom_components/sleepme_thermostat/const.py
@@ -1,9 +1,29 @@
-APP_API_URL = "https://api.developer.sleep.me/v1"
+from homeassistant.components.climate.const import (
+    HVAC_MODE_COOL,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_OFF,
+    SUPPORT_PRESET_MODE,
+    SUPPORT_TARGET_TEMPERATURE,
+)
 
-DEFAULT_API_HEADERS = {
-    "Content-Type": "application/json"
-}
-
-API_URL = APP_API_URL  # Optional: Alias for APP_API_URL for consistency
 
 DOMAIN = "sleepme_thermostat"
+MANUFACTURER = "Sleepme Inc."
+DEFAULT_API_URL = "https://api.developer.sleep.me/v1"
+
+DEFAULT_POLLING_INTERVAL_S = 60 
+DEFAULT_TIMEOUT_S = 30
+DEFAULT_RETRY_COUNT = 3
+DEFAULT_RETRY_BACKOFF_FACTOR = 30
+
+HVAC_ACTION_COOLING = "cooling"
+HVAC_ACTION_HEATING = "heating"
+HVAC_ACTION_IDLE = "idle"
+HVAC_ACTION_OFF = "off"
+HVAC_MODES = [HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_OFF]
+
+PRESET_PRECONDITIONING = "Preconditioning"
+
+SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
+
+SCHEDULE_SWITCH_NAME = "Device Schedule"

--- a/custom_components/sleepme_thermostat/manifest.json
+++ b/custom_components/sleepme_thermostat/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/rsampayo/sleepme_thermostat/issues",
-  "requirements": [],
-  "version": "3.0.0"
+  "requirements": ["aiohttp"],
+  "version": "3.0.1"
 }

--- a/custom_components/sleepme_thermostat/manifest.json
+++ b/custom_components/sleepme_thermostat/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/rsampayo/sleepme_thermostat/issues",
   "requirements": ["aiohttp"],
-  "version": "3.0.1"
+  "version": "4.0.0"
 }

--- a/custom_components/sleepme_thermostat/sensor.py
+++ b/custom_components/sleepme_thermostat/sensor.py
@@ -1,142 +1,98 @@
 import logging
-from homeassistant.components.sensor import SensorEntity
-from homeassistant.helpers.entity import EntityCategory
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PERCENTAGE, UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from .const import DOMAIN
+
+from .const import DOMAIN, MANUFACTURER
 
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_entry(hass, entry, async_add_entities):
-    """Set up SleepMe Thermostat sensors from a config entry."""
-    device_id = entry.data.get("device_id")
-    name = entry.data.get("name")
-    coordinator = hass.data[DOMAIN][f"{device_id}_update_manager"]
 
-    _LOGGER.debug(f"[Device {device_id}] Setting up sensor platform from config entry.")
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the SleepMe sensor entities."""
+    device_id = config_entry.data.get("device_id")
+    device_display_name = config_entry.data.get("display_name")
+    update_manager = hass.data[DOMAIN][f"{device_id}_update_manager"]
+    device_info_data = hass.data[DOMAIN]["device_info"]
 
-    thermostat = hass.data[DOMAIN].get(device_id)
+    sensors = [
+        SleepMeWaterLevelPercentSensor(update_manager, device_id, device_display_name, device_info_data),
+        SleepMeSetTemperatureSensor(update_manager, device_id, device_display_name, device_info_data),
+        SleepMeCurrentTemperatureSensor(update_manager, device_id, device_display_name, device_info_data),
+    ]
+    async_add_entities(sensors)
 
-    if thermostat is None:
-        _LOGGER.error(f"[Device {device_id}] Thermostat entity not found!")
-        hass.components.persistent_notification.create(
-            f"The SleepMe Thermostat entity for device {device_id} was not found. Please check the configuration.",
-            title="SleepMe Thermostat Error"
-        )
-        return
 
-    # Create the sensors and add them
-    ip_address_sensor = IPAddressSensor(coordinator, thermostat, device_id, name)
-    lan_address_sensor = LANAddressSensor(coordinator, thermostat, device_id, name)
-    brightness_level_sensor = BrightnessLevelSensor(coordinator, thermostat, device_id, name)
-    display_temp_unit_sensor = DisplayTemperatureUnitSensor(coordinator, thermostat, device_id, name)
-    time_zone_sensor = TimeZoneSensor(coordinator, thermostat, device_id, name)
+class BaseSleepMeSensor(CoordinatorEntity, SensorEntity):
+    """Base class for SleepMe sensors."""
 
-    async_add_entities([
-        ip_address_sensor, 
-        lan_address_sensor, 
-        brightness_level_sensor, 
-        display_temp_unit_sensor, 
-        time_zone_sensor
-    ])
-
-class IPAddressSensor(CoordinatorEntity, SensorEntity):
-    """Representation of a sensor that indicates the IP address."""
-
-    def __init__(self, coordinator, thermostat, device_id, name):
+    def __init__(self, coordinator, device_id, device_display_name, device_info_data, sensor_name, unique_id_suffix):
+        """Initialize the sensor."""
         super().__init__(coordinator)
-        self._thermostat = thermostat
         self._device_id = device_id
-        self._attr_name = f"Dock Pro {name} IP Address"
-        self._attr_unique_id = f"{DOMAIN}_{device_id}_ip_address"
-        self._attr_icon = "mdi:ip"
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_name = f"{device_display_name} {sensor_name}"
+        self._attr_unique_id = f"{device_id}_{unique_id_suffix}"
+        
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, self._device_id)},
+            "name": device_display_name,
+            "manufacturer": MANUFACTURER,
+            "model": device_info_data.get("model"),
+            "sw_version": device_info_data.get("firmware_version"),
+        }
 
-        # Reuse the device info from the thermostat entity
-        self._attr_device_info = thermostat.device_info
+
+class SleepMeWaterLevelPercentSensor(BaseSleepMeSensor):
+    """Representation of the water level percentage sensor."""
+
+    def __init__(self, coordinator, device_id, device_display_name, device_info_data):
+        """Initialize the sensor."""
+        super().__init__(coordinator, device_id, device_display_name, device_info_data, "Water Level", "water_level_percent")
+        self._attr_native_unit_of_measurement = PERCENTAGE
+        self._attr_icon = "mdi:water-percent"
 
     @property
-    def state(self):
-        """Return the IP address of the device."""
-        return self.coordinator.data["about"].get("ip_address")
+    def native_value(self):
+        """Return the state of the sensor."""
+        status = self.coordinator.data.get("status", {})
+        return status.get("water_level_percent")
 
-class LANAddressSensor(CoordinatorEntity, SensorEntity):
-    """Representation of a sensor that indicates the LAN address."""
 
-    def __init__(self, coordinator, thermostat, device_id, name):
-        super().__init__(coordinator)
-        self._thermostat = thermostat
-        self._device_id = device_id
-        self._attr_name = f"Dock Pro {name} LAN Address"
-        self._attr_unique_id = f"{DOMAIN}_{device_id}_lan_address"
-        self._attr_icon = "mdi:lan"
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+class SleepMeSetTemperatureSensor(BaseSleepMeSensor):
+    """Representation of the set temperature sensor."""
 
-        # Reuse the device info from the thermostat entity
-        self._attr_device_info = thermostat.device_info
+    def __init__(self, coordinator, device_id, device_display_name, device_info_data):
+        """Initialize the sensor."""
+        super().__init__(coordinator, device_id, device_display_name, device_info_data, "Set Temperature", "set_temp")
+        self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+        self._attr_device_class = SensorDeviceClass.TEMPERATURE
 
     @property
-    def state(self):
-        """Return the LAN address of the device."""
-        return self.coordinator.data["about"].get("lan_address")
+    def native_value(self):
+        """Return the state of the sensor."""
+        status = self.coordinator.data.get("status", {})
+        return status.get("set_temperature_c")
 
-class BrightnessLevelSensor(CoordinatorEntity, SensorEntity):
-    """Representation of a sensor that indicates the brightness level."""
 
-    def __init__(self, coordinator, thermostat, device_id, name):
-        super().__init__(coordinator)
-        self._thermostat = thermostat
-        self._device_id = device_id
-        self._attr_name = f"Dock Pro {name} Brightness Level"
-        self._attr_unique_id = f"{DOMAIN}_{device_id}_brightness_level"
-        self._attr_icon = "mdi:brightness-6"
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self._attr_native_unit_of_measurement = "%"  # Set unit to percentage
+class SleepMeCurrentTemperatureSensor(BaseSleepMeSensor):
+    """Representation of the current temperature sensor."""
 
-        # Reuse the device info from the thermostat entity
-        self._attr_device_info = thermostat.device_info
+    def __init__(self, coordinator, device_id, device_display_name, device_info_data):
+        """Initialize the sensor."""
+        super().__init__(coordinator, device_id, device_display_name, device_info_data, "Current Temperature", "current_temp")
+        self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+        self._attr_device_class = SensorDeviceClass.TEMPERATURE
 
     @property
-    def state(self):
-        """Return the brightness level of the device."""
-        return self.coordinator.data["control"].get("brightness_level")
-
-class DisplayTemperatureUnitSensor(CoordinatorEntity, SensorEntity):
-    """Representation of a sensor that indicates the display temperature unit."""
-
-    def __init__(self, coordinator, thermostat, device_id, name):
-        super().__init__(coordinator)
-        self._thermostat = thermostat
-        self._device_id = device_id
-        self._attr_name = f"Dock Pro {name} Display Temperature Unit"
-        self._attr_unique_id = f"{DOMAIN}_{device_id}_display_temperature_unit"
-        self._attr_icon = "mdi:thermometer"
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
-
-        # Reuse the device info from the thermostat entity
-        self._attr_device_info = thermostat.device_info
-
-    @property
-    def state(self):
-        """Return the display temperature unit of the device in uppercase."""
-        temp_unit = self.coordinator.data["control"].get("display_temperature_unit")
-        return temp_unit.upper() if temp_unit else None
-
-class TimeZoneSensor(CoordinatorEntity, SensorEntity):
-    """Representation of a sensor that indicates the time zone."""
-
-    def __init__(self, coordinator, thermostat, device_id, name):
-        super().__init__(coordinator)
-        self._thermostat = thermostat
-        self._device_id = device_id
-        self._attr_name = f"Dock Pro {name} Time Zone"
-        self._attr_unique_id = f"{DOMAIN}_{device_id}_time_zone"
-        self._attr_icon = "mdi:earth"
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
-
-        # Reuse the device info from the thermostat entity
-        self._attr_device_info = thermostat.device_info
-
-    @property
-    def state(self):
-        """Return the time zone of the device."""
-        return self.coordinator.data["control"].get("time_zone")
+    def native_value(self):
+        """Return the state of the sensor."""
+        status = self.coordinator.data.get("status", {})
+        return status.get("current_temperature_c")

--- a/custom_components/sleepme_thermostat/sleepme.py
+++ b/custom_components/sleepme_thermostat/sleepme.py
@@ -12,6 +12,10 @@ class SleepMeClient:
         self._api = SleepMeAPI(api_url, token, device_id)
         self.device_id = device_id
 
+    async def get_all_devices(self):
+        """Get a list of all devices from the API."""
+        return await self._api.get_all_devices()
+
     async def get_device_status(self):
         """Get the full status of the device."""
         return await self._api.get_device_status()

--- a/custom_components/sleepme_thermostat/sleepme.py
+++ b/custom_components/sleepme_thermostat/sleepme.py
@@ -23,44 +23,29 @@ class SleepMeClient:
 
     async def set_temperature(self, temperature_c: float) -> bool:
         """Set the target temperature of the device in Celsius."""
-        _LOGGER.debug(f"[Device {self.device_id}] Setting temperature to {temperature_c}C")
-        payload = {"setTemperatureC": temperature_c}
+        _LOGGER.debug(f"[Device {self.device_id}] Sending command to set temperature to {temperature_c}C")
+        payload = {"set_temperature_c": temperature_c}
         response = await self._api.patch_device_control(payload)
-        if response and response.get("set_temperature_c") == temperature_c:
-            return True
-        _LOGGER.warning(
-            f"[Device {self.device_id}] Temperature may not have been set to {temperature_c}C. Response: {response}"
-        )
-        return False
+        return response is not None
 
     async def set_power_status(self, is_active: bool) -> bool:
         """Set the power status of the device."""
         target_status = "active" if is_active else "standby"
-        _LOGGER.debug(f"[Device {self.device_id}] Setting power status to {target_status}")
-        payload = {"thermalControlStatus": target_status}
+        _LOGGER.debug(f"[Device {self.device_id}] Sending command to set power status to {target_status}")
+        payload = {"thermal_control_status": target_status}
         response = await self._api.patch_device_control(payload)
-        if response and response.get("thermal_control_status") == target_status:
-            return True
-        _LOGGER.warning(
-            f"[Device {self.device_id}] Device status may not have been set to {target_status}. Response: {response}"
-        )
-        return False
+        return response is not None
 
     async def set_schedule_enabled(self, enabled: bool) -> bool:
         """Enable or disable the device's internal schedule."""
-        _LOGGER.debug(f"[Device {self.device_id}] Setting schedule enabled to {enabled}")
-        payload = {"hasScheduleEnabled": enabled}
+        _LOGGER.debug(f"[Device {self.device_id}] Sending command to set schedule enabled to {enabled}")
+        payload = {"has_schedule_enabled": enabled}
         response = await self._api.patch_device_control(payload)
-        if response and response.get("has_schedule_enabled") == enabled:
-            return True
-        _LOGGER.warning(
-            f"[Device {self.device_id}] Schedule enabled may not have been set to {enabled}. Response: {response}"
-        )
-        return False
+        return response is not None
 
     async def set_display_brightness(self, brightness_percent: int) -> bool:
         """Set the display brightness."""
-        _LOGGER.debug(f"[Device {self.device_id}] Setting brightness to {brightness_percent}%")
-        payload = {"brightnessLevel": brightness_percent}
+        _LOGGER.debug(f"[Device {self.device_id}] Sending command to set brightness to {brightness_percent}%")
+        payload = {"brightness_level_percent": brightness_percent}
         response = await self._api.patch_device_control(payload)
         return response is not None

--- a/custom_components/sleepme_thermostat/sleepme.py
+++ b/custom_components/sleepme_thermostat/sleepme.py
@@ -1,4 +1,5 @@
 import logging
+import aiohttp
 from .sleepme_api import SleepMeAPI
 
 _LOGGER = logging.getLogger(__name__)
@@ -7,9 +8,9 @@ _LOGGER = logging.getLogger(__name__)
 class SleepMeClient:
     """A client for interacting with SleepMe devices."""
 
-    def __init__(self, api_url, token, device_id):
+    def __init__(self, session: aiohttp.ClientSession, api_url, token, device_id):
         """Initialize the client."""
-        self._api = SleepMeAPI(api_url, token, device_id)
+        self._api = SleepMeAPI(session, api_url, token, device_id)
         self.device_id = device_id
 
     async def get_all_devices(self):

--- a/custom_components/sleepme_thermostat/sleepme_api.py
+++ b/custom_components/sleepme_thermostat/sleepme_api.py
@@ -1,13 +1,13 @@
 import logging
-import time
-import httpx
+import aiohttp
 
 _LOGGER = logging.getLogger(__name__)
 
 class SleepMeAPI:
     """A low-level client for the SleepMe API."""
 
-    def __init__(self, api_url, token, device_id):
+    # --- THIS ENTIRE SECTION IS CORRECTED ---
+    def __init__(self, session: aiohttp.ClientSession, api_url, token, device_id):
         """Initialize the API client."""
         self.base_url = api_url
         self.headers = {
@@ -15,16 +15,16 @@ class SleepMeAPI:
             "Authorization": f"Bearer {token}",
         }
         self.device_id = device_id
-        self.client = httpx.AsyncClient()
-
+        self.client = session 
+    
     async def get_all_devices(self):
         """Get a list of all devices from the API."""
         url = f"{self.base_url}/devices"
         try:
-            response = await self.client.get(url, headers=self.headers)
-            response.raise_for_status() 
-            return response.json()
-        except httpx.RequestError as e:
+            async with self.client.get(url, headers=self.headers) as response:
+                response.raise_for_status()
+                return await response.json()
+        except aiohttp.ClientError as e:
             _LOGGER.error(f"Error requesting all devices: {e}")
             return None
 
@@ -34,10 +34,10 @@ class SleepMeAPI:
             return None
         url = f"{self.base_url}/devices/{self.device_id}"
         try:
-            response = await self.client.get(url, headers=self.headers)
-            response.raise_for_status()
-            return response.json()
-        except httpx.RequestError as e:
+            async with self.client.get(url, headers=self.headers) as response:
+                response.raise_for_status()
+                return await response.json()
+        except aiohttp.ClientError as e:
             _LOGGER.error(f"Error requesting device status for {self.device_id}: {e}")
             return None
 
@@ -47,9 +47,9 @@ class SleepMeAPI:
             return None
         url = f"{self.base_url}/devices/{self.device_id}"
         try:
-            response = await self.client.patch(url, headers=self.headers, json=payload)
-            response.raise_for_status()
-            return response.json()
-        except httpx.RequestError as e:
+            async with self.client.patch(url, headers=self.headers, json=payload) as response:
+                response.raise_for_status()
+                return await response.json()
+        except aiohttp.ClientError as e:
             _LOGGER.error(f"Error sending command to {self.device_id}: {e}")
             return None

--- a/custom_components/sleepme_thermostat/sleepme_api.py
+++ b/custom_components/sleepme_thermostat/sleepme_api.py
@@ -1,106 +1,55 @@
-import asyncio
-import httpx
 import logging
 import time
-from collections import deque
+import httpx
 
 _LOGGER = logging.getLogger(__name__)
 
 class SleepMeAPI:
-    def __init__(self, api_url: str, token: str, max_requests_per_minute=9):
-        self.api_url = api_url
-        self.token = token
+    """A low-level client for the SleepMe API."""
+
+    def __init__(self, api_url, token, device_id):
+        """Initialize the API client."""
+        self.base_url = api_url
+        self.headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        }
+        self.device_id = device_id
         self.client = httpx.AsyncClient()
-        self.request_times = deque(maxlen=max_requests_per_minute)
-        self.rate_limit_interval = 60  # seconds
 
-    async def api_request(self, method: str, endpoint: str, params=None, data=None, input_headers=None, retries=3):
-        """Handles rate limiting, retries, and calls perform_request."""
-        request_id = f"{method.upper()}-{endpoint}-{int(time.time())}"
-        _LOGGER.debug(f"[{request_id}] Starting API request with {retries} retries remaining.")
-
-        async with asyncio.Lock():
-            current_time = time.time()
-
-            # Rate limiting logic
-            if len(self.request_times) == self.request_times.maxlen and current_time - self.request_times[0] < self.rate_limit_interval:
-                wait_time = self.rate_limit_interval - (current_time - self.request_times[0])
-
-                if method.upper() == "GET":
-                    _LOGGER.warning(f"[{request_id}] Rate limiting active. Discarding GET request to {endpoint} instead of delaying by {wait_time:.2f} seconds.")
-                    return {}  # Discard the GET request and return an empty dictionary
-
-                _LOGGER.debug(f"[{request_id}] Rate limiting: waiting for {wait_time:.2f} seconds before making {method.upper()} request to {endpoint}.")
-                await asyncio.sleep(wait_time)
-
-            # Add the current time to the deque
-            self.request_times.append(current_time)
-
-        # Perform the API request
+    async def get_all_devices(self):
+        """Get a list of all devices from the API."""
+        url = f"{self.base_url}/devices"
         try:
-            result = await self.perform_request(method, endpoint, params=params, data=data, input_headers=input_headers)
-            _LOGGER.debug(f"[{request_id}] API request successful.")
-            return result
-        except Exception as e:
-            _LOGGER.debug(f"[{request_id}] Exception occurred: {e}. Passing to handle_error.")
-            return await self.handle_error(e, method, endpoint, params, data, input_headers, retries)
+            response = await self.client.get(url, headers=self.headers)
+            response.raise_for_status() 
+            return response.json()
+        except httpx.RequestError as e:
+            _LOGGER.error(f"Error requesting all devices: {e}")
+            return None
 
-    async def perform_request(self, method: str, endpoint: str, params=None, data=None, input_headers=None):
-        """Executes the actual API request."""
-        request_id = f"{method.upper()}-{endpoint}-{int(time.time())}"
-        headers = input_headers or {}
-        headers["Authorization"] = f"Bearer {self.token}"
+    async def get_device_status(self):
+        """Get the status of a specific device."""
+        if not self.device_id:
+            return None
+        url = f"{self.base_url}/devices/{self.device_id}"
+        try:
+            response = await self.client.get(url, headers=self.headers)
+            response.raise_for_status()
+            return response.json()
+        except httpx.RequestError as e:
+            _LOGGER.error(f"Error requesting device status for {self.device_id}: {e}")
+            return None
 
-        _LOGGER.debug(f"[{request_id}] Making {method.upper()} request to {self.api_url}/{endpoint} with params: {params} and data: {data}")
-        response = await self.client.request(method, f"{self.api_url}/{endpoint}", headers=headers, json=data, params=params)
-        response.raise_for_status()
-        _LOGGER.debug(f"[{request_id}] Request to {endpoint} completed successfully with status {response.status_code}.")
-        return response.json()  # Process and return the JSON response
-
-    async def handle_error(self, error, method: str, endpoint: str, params=None, data=None, input_headers=None, retries=3):
-        """Classifies errors and applies backoff before retrying if necessary."""
-        request_id = f"{method.upper()}-{endpoint}-{int(time.time())}"
-
-        if retries <= 0:
-            _LOGGER.debug(f"[{request_id}] API request to {endpoint} failed after all retries.")
-            return {}  # Return an empty dictionary on failure
-
-        _LOGGER.warning(f"[{request_id}] Handling error: {error}. Retries remaining: {retries}")
-
-        # Determine backoff time based on error type
-        if isinstance(error, httpx.HTTPStatusError):
-            if error.response.status_code == 403:
-                _LOGGER.debug(f"[{request_id}] Invalid API token. Received 403 Forbidden for {self.api_url}/{endpoint}.")
-                raise ValueError("invalid_token")
-            elif error.response.status_code == 429:
-                # Backoff times: 30, 60, 120, 240... seconds for 429 errors
-                initial_backoff = 30
-                _LOGGER.warning(f"[{request_id}] 429 Too Many Requests. Applying backoff starting at {initial_backoff} seconds.")
-            elif error.response.status_code in {500, 502, 503, 504}:
-                # Backoff times: 10, 20, 40, 80... seconds for server errors
-                initial_backoff = 10
-                _LOGGER.warning(f"[{request_id}] Server error {error.response.status_code}. Applying backoff starting at {initial_backoff} seconds.")
-            else:
-                _LOGGER.debug(f"[{request_id}] HTTP error {error.response.status_code}. No retry configured.")
-                raise ValueError("cannot_connect")
-        elif isinstance(error, httpx.TimeoutException):
-            # Backoff times: 10, 20, 40, 80... seconds for timeouts
-            initial_backoff = 10
-            _LOGGER.warning(f"[{request_id}] Timeout occurred. Applying backoff starting at {initial_backoff} seconds.")
-        elif isinstance(error, httpx.RequestError):
-            _LOGGER.debug(f"[{request_id}] Request error: {error}. Cannot connect.")
-            raise ValueError("cannot_connect")
-
-        backoff_time = initial_backoff * (2 ** (retries - 1))
-        _LOGGER.warning(f"[{request_id}] Retrying after {backoff_time} seconds. Retries left: {retries-1}")
-
-        await asyncio.sleep(backoff_time)
-
-        # Retry the API request with one less retry
-        return await self.api_request(method, endpoint, params=params, data=data, input_headers=input_headers, retries=retries-1)
-
-    async def close(self):
-        """Close the httpx client."""
-        _LOGGER.debug("Closing HTTP client...")
-        await self.client.aclose()
-        _LOGGER.debug("HTTP client closed.")
+    async def patch_device_control(self, payload):
+        """Send a PATCH request to control the device."""
+        if not self.device_id:
+            return None
+        url = f"{self.base_url}/devices/{self.device_id}"
+        try:
+            response = await self.client.patch(url, headers=self.headers, json=payload)
+            response.raise_for_status()
+            return response.json()
+        except httpx.RequestError as e:
+            _LOGGER.error(f"Error sending command to {self.device_id}: {e}")
+            return None

--- a/custom_components/sleepme_thermostat/strings.json
+++ b/custom_components/sleepme_thermostat/strings.json
@@ -1,0 +1,35 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "SleepMe Thermostat Setup",
+        "description": "Enter your SleepMe API token. You can obtain this from the SleepMe developer portal.",
+        "data": {
+          "api_token": "API Token"
+        }
+      },
+      "select_device": {
+        "title": "Select Your Device",
+        "description": "Choose the SleepMe device you want to add to Home Assistant.",
+        "data": {
+          "device_id": "Device"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to the SleepMe API. Please check your token and network connection.",
+      "invalid_auth": "Invalid authentication. Please check your API token.",
+      "no_devices_found": "No SleepMe devices found for this account."
+    },
+    "abort": {
+      "already_configured": "This SleepMe device is already configured."
+    }
+  },
+  "entity": {
+    "switch": {
+      "device_schedule": {
+        "name": "Device Schedule"
+      }
+    }
+  }
+}

--- a/custom_components/sleepme_thermostat/switch.py
+++ b/custom_components/sleepme_thermostat/switch.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MANUFACTURER, SCHEDULE_SWITCH_NAME
-from .pysleepme import SleepMeClient
+from .sleepme import SleepMeClient
 from .update_manager import SleepMeUpdateManager
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/sleepme_thermostat/switch.py
+++ b/custom_components/sleepme_thermostat/switch.py
@@ -1,0 +1,84 @@
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MANUFACTURER, SCHEDULE_SWITCH_NAME
+from .pysleepme import SleepMeClient
+from .update_manager import SleepMeUpdateManager
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the SleepMe switch entities."""
+    device_id = config_entry.data.get("device_id")
+    device_display_name = config_entry.data.get("device_display_name")
+    update_manager = hass.data[DOMAIN][f"{device_id}_update_manager"]
+    client = hass.data[DOMAIN]["sleepme_controller"]
+    device_info_data = hass.data[DOMAIN]["device_info"]
+
+    async_add_entities(
+        [
+            SleepMeScheduleSwitch(
+                update_manager, client, device_id, device_display_name, device_info_data
+            )
+        ]
+    )
+
+
+class SleepMeScheduleSwitch(CoordinatorEntity, SwitchEntity):
+    """Representation of a SleepMe schedule switch."""
+
+    def __init__(
+        self,
+        coordinator: SleepMeUpdateManager,
+        client: SleepMeClient,
+        device_id: str,
+        device_display_name: str,
+        device_info_data: dict,
+    ):
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self.client = client
+        self._device_id = device_id
+        self._attr_name = f"{device_display_name} {SCHEDULE_SWITCH_NAME}"
+        self._attr_unique_id = f"{device_id}_schedule_switch"
+
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, self._device_id)},
+            "name": device_display_name,
+            "manufacturer": MANUFACTURER,
+            "model": device_info_data.get("model"),
+            "sw_version": device_info_data.get("firmware_version"),
+        }
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the schedule is enabled."""
+        control = self.coordinator.data.get("control", {})
+        return control.get("has_schedule_enabled", False)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the device schedule on."""
+        if await self.client.set_schedule_enabled(True):
+            control = self.coordinator.data.get("control", {})
+            control["has_schedule_enabled"] = True
+            self.async_write_ha_state()
+            await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the device schedule off."""
+        if await self.client.set_schedule_enabled(False):
+            control = self.coordinator.data.get("control", {})
+            control["has_schedule_enabled"] = False
+            self.async_write_ha_state()
+            await self.coordinator.async_request_refresh()

--- a/custom_components/sleepme_thermostat/update_manager.py
+++ b/custom_components/sleepme_thermostat/update_manager.py
@@ -1,47 +1,34 @@
-# custom_components/sleepme_thermostat/update_manager.py
-
 import logging
-from datetime import timedelta
-from typing import Any
-
-from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-
-from .pysleepme import SleepMeClient, SleepMeClientError
+from homeassistant.core import HomeAssistant
+from datetime import timedelta
+from .sleepme import SleepMeClient
 
 _LOGGER = logging.getLogger(__name__)
 
-UPDATE_INTERVAL_SECONDS = 20
-
 class SleepMeUpdateManager(DataUpdateCoordinator):
-    """Manages data updates and communication with the SleepMe API."""
+    """Manages data updates for SleepMe devices."""
 
     def __init__(self, hass: HomeAssistant, client: SleepMeClient):
         """Initialize the update manager."""
         self.client = client
+        self.device_id = client.device_id
+
+        # Set the update interval to 60 seconds
+        update_interval = timedelta(seconds=60)
 
         super().__init__(
             hass,
             _LOGGER,
-            name=f"SleepMe Dock Pro {client.device_id}",
-            update_interval=timedelta(seconds=UPDATE_INTERVAL_SECONDS),
+            name=f"SleepMe Update Manager {self.device_id}",
+            update_interval=update_interval,
         )
 
-    async def _async_update_data(self) -> dict[str, Any]:
-        """
-        Fetch the latest data from the SleepMe API.
-
-        This method is called by the DataUpdateCoordinator to refresh the data.
-        If it fails, it raises UpdateFailed to notify Home Assistant.
-        """
+    async def _async_update_data(self):
+        """Fetch the latest data from the SleepMe API."""
         try:
             device_status = await self.client.get_device_status()
-
             if not device_status:
-                _LOGGER.debug(
-                    "Failed to update device %s: API returned an empty response",
-                    self.client.device_id,
-                )
                 raise UpdateFailed("API returned an empty response.")
 
             return {
@@ -49,17 +36,5 @@ class SleepMeUpdateManager(DataUpdateCoordinator):
                 "control": device_status.get("control", {}),
                 "about": device_status.get("about", {}),
             }
-
-        except SleepMeClientError as err:
-            _LOGGER.warning(
-                "Failed to update device %s: %s", self.client.device_id, err
-            )
-            raise UpdateFailed(f"Error communicating with SleepMe API: {err}") from err
-            
-        except Exception as err:
-            _LOGGER.error(
-                "An unexpected error occurred while updating device %s: %s",
-                self.client.device_id,
-                err,
-            )
-            raise UpdateFailed(f"An unexpected error occurred: {err}") from err
+        except Exception as e:
+            raise UpdateFailed(f"Error updating device data for {self.device_id}: {e}") from e

--- a/custom_components/sleepme_thermostat/update_manager.py
+++ b/custom_components/sleepme_thermostat/update_manager.py
@@ -11,7 +11,6 @@ from .pysleepme import SleepMeClient, SleepMeClientError
 
 _LOGGER = logging.getLogger(__name__)
 
-# Define how often to poll the API
 UPDATE_INTERVAL_SECONDS = 20
 
 class SleepMeUpdateManager(DataUpdateCoordinator):
@@ -36,10 +35,8 @@ class SleepMeUpdateManager(DataUpdateCoordinator):
         If it fails, it raises UpdateFailed to notify Home Assistant.
         """
         try:
-            # Fetch device status from the underlying client library
             device_status = await self.client.get_device_status()
 
-            # The API can sometimes return an empty response, which is a failure condition.
             if not device_status:
                 _LOGGER.debug(
                     "Failed to update device %s: API returned an empty response",
@@ -47,8 +44,6 @@ class SleepMeUpdateManager(DataUpdateCoordinator):
                 )
                 raise UpdateFailed("API returned an empty response.")
 
-            # If successful, return the structured data.
-            # The coordinator will store this in `self.data` for all entities to use.
             return {
                 "status": device_status.get("status", {}),
                 "control": device_status.get("control", {}),
@@ -56,15 +51,12 @@ class SleepMeUpdateManager(DataUpdateCoordinator):
             }
 
         except SleepMeClientError as err:
-            # Catch specific errors from our client library.
-            # This allows for more granular error handling if needed in the future.
             _LOGGER.warning(
                 "Failed to update device %s: %s", self.client.device_id, err
             )
             raise UpdateFailed(f"Error communicating with SleepMe API: {err}") from err
             
         except Exception as err:
-            # Catch any other unexpected exceptions.
             _LOGGER.error(
                 "An unexpected error occurred while updating device %s: %s",
                 self.client.device_id,


### PR DESCRIPTION
This "should" be of value unless I messed up. 

The goal is to ensure that the updater is showing errors and not using old, stale data on failures.  Also, the init is updated to reflect one single client and adding async_forward_entry_setups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a schedule switch entity to enable or disable the device schedule.
  - Introduced localization strings for configuration UI and error messages.

- **Bug Fixes**
  - Improved update logic with immediate error reporting on data fetch failures for clearer status feedback.

- **Refactor**
  - Modernized climate entity with explicit HVAC modes, actions, and streamlined temperature setting.
  - Simplified client interface for device communication with clearer success indicators.
  - Expanded and standardized configuration constants aligned with Home Assistant climate integration.
  - Streamlined configuration flow for easier and more reliable device setup and selection.
  - Redesigned API client for simpler, direct HTTP requests without rate limiting or retries.
  - Enhanced update manager for more robust and maintainable data handling.

- **Chores**
  - Updated integration version to 4.0.0 and added aiohttp as a dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->