### PR TITLE
Fix missing hass object in SleepMeClient flow

### DIFF
--- a/custom_components/sleepme_thermostat/manifest.json
+++ b/custom_components/sleepme_thermostat/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "sleepme_thermostat",
   "name": "SleepMe Thermostat",
-  "codeowners": ["@rsampayo", "@mikesalz"],
+  "codeowners": ["@rsampayo", "@mikesalz","@derekcentrico"],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/rsampayo/sleepme_thermostat",
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/rsampayo/sleepme_thermostat/issues",
   "requirements": [],
-  "version": "3.2.1"
+  "version": "3.2.2"
 }


### PR DESCRIPTION
Error in config_flow for setup after other changes. I apparently forgot to push those as well. Apologies all. 

Fix for https://github.com/rsampayo/sleepme_thermostat/issues/30


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the integration version to 3.2.2.
  * Added a new code owner for the integration.

* **Style**
  * Removed commented lines from the configuration flow to improve code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->