### PR TITLE
Fix translation device name

### DIFF
--- a/custom_components/sleepme_thermostat/translations/en.json
+++ b/custom_components/sleepme_thermostat/translations/en.json
@@ -14,7 +14,7 @@
       },
       "select_device": {
         "title": "Select Dock Pro Device",
-        "description": "Select the Docker Pro device you want to add.",
+        "description": "Select the Dock Pro device you want to add.",
         "data": {
           "device_id": "Device"
         },


### PR DESCRIPTION
## Summary
- fix device name in config dialog translation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d3a5721a0832cacecf7ae9daa5310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typographical error in the English translation for the "select_device" step, replacing "Docker" with "Dock".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->