### PR TITLE
Add sleep report sensor

### DIFF
--- a/custom_components/sleepme_thermostat/__init__.py
+++ b/custom_components/sleepme_thermostat/__init__.py
@@ -3,7 +3,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from .sleepme import SleepMeClient
-from .update_manager import SleepMeUpdateManager
+from .update_manager import SleepMeUpdateManager, SleepReportUpdateManager
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,7 +48,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     update_manager = SleepMeUpdateManager(hass, api_url, api_token, device_id)
     hass.data[DOMAIN][f"{device_id}_update_manager"] = update_manager
 
+    sleep_report_manager = SleepReportUpdateManager(hass, api_url, api_token)
+    hass.data[DOMAIN][f"{device_id}_sleep_report_manager"] = sleep_report_manager
+
     await update_manager.async_config_entry_first_refresh()
+    await sleep_report_manager.async_config_entry_first_refresh()
 
     hass.data[DOMAIN]["device_info"] = {
         "firmware_version": firmware_version,

--- a/custom_components/sleepme_thermostat/sensor.py
+++ b/custom_components/sleepme_thermostat/sensor.py
@@ -11,6 +11,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     device_id = entry.data.get("device_id")
     name = entry.data.get("name")
     coordinator = hass.data[DOMAIN][f"{device_id}_update_manager"]
+    sleep_report_coordinator = hass.data[DOMAIN][f"{device_id}_sleep_report_manager"]
 
     _LOGGER.debug(f"[Device {device_id}] Setting up sensor platform from config entry.")
 
@@ -30,13 +31,15 @@ async def async_setup_entry(hass, entry, async_add_entities):
     brightness_level_sensor = BrightnessLevelSensor(coordinator, thermostat, device_id, name)
     display_temp_unit_sensor = DisplayTemperatureUnitSensor(coordinator, thermostat, device_id, name)
     time_zone_sensor = TimeZoneSensor(coordinator, thermostat, device_id, name)
+    sleep_score_sensor = SleepScoreSensor(sleep_report_coordinator, device_id, name)
 
     async_add_entities([
-        ip_address_sensor, 
-        lan_address_sensor, 
-        brightness_level_sensor, 
-        display_temp_unit_sensor, 
-        time_zone_sensor
+        ip_address_sensor,
+        lan_address_sensor,
+        brightness_level_sensor,
+        display_temp_unit_sensor,
+        time_zone_sensor,
+        sleep_score_sensor,
     ])
 
 class IPAddressSensor(CoordinatorEntity, SensorEntity):
@@ -140,3 +143,19 @@ class TimeZoneSensor(CoordinatorEntity, SensorEntity):
     def state(self):
         """Return the time zone of the device."""
         return self.coordinator.data["control"].get("time_zone")
+
+
+class SleepScoreSensor(CoordinatorEntity, SensorEntity):
+    """Sensor for displaying the latest sleep score."""
+
+    def __init__(self, coordinator, device_id, name):
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._attr_name = f"Dock Pro {name} Sleep Score"
+        self._attr_unique_id = f"{DOMAIN}_{device_id}_sleep_score"
+        self._attr_icon = "mdi:sleep"
+        self._attr_native_unit_of_measurement = "%"
+
+    @property
+    def state(self):
+        return self.coordinator.data.get("sleep_score_percent")

--- a/custom_components/sleepme_thermostat/sleepme.py
+++ b/custom_components/sleepme_thermostat/sleepme.py
@@ -81,3 +81,21 @@ class SleepMeClient:
         
         _LOGGER.error(f"Failed to fetch device status for {self.device_id}. Response: {response}")
         return {}
+
+    async def get_sleep_report(self, start_date: str | None = None, days_back: int = 0, time_zone: str = "UTC", retries: int = 1):
+        """Retrieve sleep report data for the account."""
+        endpoint = "sleep-reports"
+        params = {"days_back": days_back, "time_zone": time_zone}
+        if start_date:
+            params["start_date"] = start_date
+
+        _LOGGER.debug(f"Fetching sleep report from {endpoint} with params: {params}")
+
+        response = await self.api.api_request("GET", endpoint, params=params, retries=retries)
+
+        if isinstance(response, dict):
+            _LOGGER.debug(f"Sleep report fetched: {response}")
+            return response
+
+        _LOGGER.error(f"Unexpected response format for sleep report: {response}")
+        return {}

--- a/custom_components/sleepme_thermostat/update_manager.py
+++ b/custom_components/sleepme_thermostat/update_manager.py
@@ -58,3 +58,29 @@ class SleepMeUpdateManager(DataUpdateCoordinator):
                 "control": {},
                 "about": {},
             }
+
+
+class SleepReportUpdateManager(DataUpdateCoordinator):
+    """Fetches periodic sleep report information."""
+
+    def __init__(self, hass: HomeAssistant, api_url: str, token: str):
+        self.client = SleepMeClient(hass, api_url, token)
+
+        update_interval = timedelta(hours=1)
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="SleepMe Sleep Report Manager",
+            update_interval=update_interval,
+        )
+
+    async def _async_update_data(self):
+        try:
+            report = await self.client.get_sleep_report()
+            if report and report.get("reports"):
+                return report["reports"][0]
+            return {}
+        except Exception as e:
+            _LOGGER.error(f"Error updating sleep report: {e}")
+            return {}

--- a/tests/test_sleep_reports.py
+++ b/tests/test_sleep_reports.py
@@ -1,0 +1,53 @@
+import sys
+import types
+import os
+import importlib
+import pytest
+
+# Ensure repository root and custom_components are on sys.path
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, "custom_components"))
+
+# Stub minimal homeassistant modules to satisfy imports
+ha = types.ModuleType('homeassistant')
+ha.helpers = types.ModuleType('homeassistant.helpers')
+ha.helpers.httpx_client = types.ModuleType('homeassistant.helpers.httpx_client')
+async def get_async_client(hass):
+    class DummyClient:
+        async def request(self, method, url, headers=None, json=None, params=None):
+            class Response:
+                status_code = 200
+                def json(self):
+                    return {}
+                def raise_for_status(self):
+                    pass
+            return Response()
+        async def aclose(self):
+            pass
+    return DummyClient()
+ha.helpers.httpx_client.get_async_client = get_async_client
+ha.core = types.ModuleType('homeassistant.core')
+ha.core.HomeAssistant = type('HomeAssistant', (), {})
+
+sys.modules['homeassistant'] = ha
+sys.modules['homeassistant.helpers'] = ha.helpers
+sys.modules['homeassistant.helpers.httpx_client'] = ha.helpers.httpx_client
+sys.modules['homeassistant.core'] = ha.core
+
+sleepme_module = importlib.import_module('custom_components.sleepme_thermostat.sleepme')
+
+class DummyAPI:
+    def __init__(self, hass, api_url, token, max_requests_per_minute=9):
+        self.calls = []
+    async def api_request(self, method, endpoint, params=None, data=None, input_headers=None, retries=3):
+        self.calls.append((method, endpoint, params))
+        return {"reports": [{"sleep_score_percent": 90}]}
+
+sleepme_module.SleepMeAPI = DummyAPI
+
+@pytest.mark.asyncio
+async def test_get_sleep_report():
+    client = sleepme_module.SleepMeClient(None, 'http://mock', 'token')
+    report = await client.get_sleep_report(start_date='2024-01-01', days_back=1)
+    assert report['reports'][0]['sleep_score_percent'] == 90


### PR DESCRIPTION
## Summary
- add new SleepMeClient method to fetch sleep reports
- fetch sleep reports periodically via `SleepReportUpdateManager`
- expose latest sleep score with a new sensor
- add a test stub for new functionality

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'homeassistant.config_entries')*

------
https://chatgpt.com/codex/tasks/task_e_688441974d70832cb6b0c96ecee43a65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new sensor that displays your sleep score percentage.
  * Integrated sleep report data retrieval and periodic updates.
* **Bug Fixes**
  * Improved handling of unexpected or empty sleep report data.
* **Tests**
  * Introduced new tests to verify sleep report retrieval and sensor accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->