### PR TITLE
fix: HA 2024.8+ compatibility (FlowResult removed from data_entry_flow)

### DIFF
--- a/custom_components/sleepme_thermostat/config_flow.py
+++ b/custom_components/sleepme_thermostat/config_flow.py
@@ -1,7 +1,10 @@
 import logging
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.data_entry_flow import FlowResult
+try:
+    from homeassistant.config_entries import ConfigFlowResult as FlowResult
+except ImportError:
+    from homeassistant.data_entry_flow import FlowResult  # type: ignore[no-redef]
 from .sleepme import SleepMeClient
 from .const import DOMAIN, API_URL
 from httpx import HTTPStatusError


### PR DESCRIPTION
## Problem

\`FlowResult\` was removed from \`homeassistant.data_entry_flow\` in HA 2024.8. On HA 2024.8+ (including 2025.x and 2026.x), the component silently fails to load at startup with an \`ImportError\`, and no entities are created.

## Fix

Import \`ConfigFlowResult\` from \`homeassistant.config_entries\` instead, with a fallback for older HA installs:

\`\`\`python
try:
    from homeassistant.config_entries import ConfigFlowResult as FlowResult
except ImportError:
    from homeassistant.data_entry_flow import FlowResult  # type: ignore[no-redef]
\`\`\`

This keeps backwards compatibility with older HA versions while fixing the crash on 2024.8+.

## Testing

Verified on HA 2026.5.1 — component loads and config flow appears in the integrations UI after this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved compatibility with multiple Home Assistant versions through conditional import fallback mechanism.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rsampayo/sleepme_thermostat/pull/37)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->