### PR TITLE
Phase 1: P0 fixes — transport rewrite, coordinator, unload, reauth

### DIFF
--- a/custom_components/sleepme_thermostat/__init__.py
+++ b/custom_components/sleepme_thermostat/__init__.py
@@ -1,65 +1,72 @@
+"""SleepMe Thermostat custom integration."""
+
+from __future__ import annotations
+
 import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
+
+from .const import API_URL, DOMAIN
 from .sleepme import SleepMeClient
 from .update_manager import SleepMeUpdateManager
-from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
+PLATFORMS = ["climate", "binary_sensor", "sensor"]
+
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
-    """Set up the SleepMe Thermostat component."""
-    _LOGGER.debug("Starting async_setup for SleepMe Thermostat.")
+    """Set up the SleepMe Thermostat component (YAML hook — unused)."""
     hass.data.setdefault(DOMAIN, {})
     return True
 
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up SleepMe Thermostat from a config entry."""
-    _LOGGER.debug("Starting async_setup_entry for SleepMe Thermostat.")
-
-    api_url = entry.data.get("api_url")
+    api_url = entry.data.get("api_url") or API_URL
     api_token = entry.data.get("api_token")
     device_id = entry.data.get("device_id")
 
-    firmware_version = entry.data.get("firmware_version")
-    mac_address = entry.data.get("mac_address")
-    model = entry.data.get("model")
-    serial_number = entry.data.get("serial_number")
-
-    _LOGGER.debug(f"API URL: {api_url}")
-    _LOGGER.debug(f"API Token: {api_token}")
-    _LOGGER.debug(f"Device ID: {device_id}")
-    _LOGGER.debug(f"Firmware Version: {firmware_version}")
-    _LOGGER.debug(f"MAC Address: {mac_address}")
-    _LOGGER.debug(f"Model: {model}")
-    _LOGGER.debug(f"Serial Number: {serial_number}")
-
     if not api_token or not device_id:
-        _LOGGER.error("API token or device ID is missing from configuration.")
-        return False
+        raise ConfigEntryNotReady("API token or device ID missing from entry data")
 
-    sleepme_controller = SleepMeClient(hass, api_url, api_token, device_id)
-    hass.data[DOMAIN]["sleepme_controller"] = sleepme_controller
+    client = SleepMeClient(hass, api_url, api_token, device_id)
+    coordinator = SleepMeUpdateManager(hass, api_url, api_token, device_id)
 
-    update_manager = SleepMeUpdateManager(hass, api_url, api_token, device_id)
-    hass.data[DOMAIN][f"{device_id}_update_manager"] = update_manager
+    # First refresh propagates ConfigEntryAuthFailed (-> reauth flow) and
+    # ConfigEntryNotReady (-> HA retries setup) without further plumbing.
+    await coordinator.async_config_entry_first_refresh()
 
-    await update_manager.async_config_entry_first_refresh()
-
-    hass.data[DOMAIN]["device_info"] = {
-        "firmware_version": firmware_version,
-        "mac_address": mac_address,
-        "model": model,
-        "serial_number": serial_number,
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "client": client,
+        "coordinator": coordinator,
+        "device_info": {
+            "firmware_version": entry.data.get("firmware_version"),
+            "mac_address": entry.data.get("mac_address"),
+            "model": entry.data.get("model"),
+            "serial_number": entry.data.get("serial_number"),
+        },
     }
 
-    _LOGGER.debug(f"SleepMeClient and Update Manager initialized and stored in hass.data for device {device_id}.")
-
-    await hass.config_entries.async_forward_entry_setups(entry, ["climate", "binary_sensor", "sensor"])
-
-    _LOGGER.info("SleepMe Thermostat component initialized successfully.")
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    _LOGGER.debug(
+        "Entry %s set up for device %s (model=%s, fw=%s)",
+        entry.entry_id,
+        device_id,
+        entry.data.get("model"),
+        entry.data.get("firmware_version"),
+    )
     return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unloaded:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+    return unloaded

--- a/custom_components/sleepme_thermostat/binary_sensor.py
+++ b/custom_components/sleepme_thermostat/binary_sensor.py
@@ -1,68 +1,76 @@
+"""Binary sensors for SleepMe Dock Pro: water-level-low + connected."""
+
+from __future__ import annotations
+
 import logging
+
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _device_info(device_id: str, name: str, info: dict) -> dict:
+    return {
+        "identifiers": {(DOMAIN, device_id)},
+        "name": f"Dock Pro {name}",
+        "manufacturer": "SleepMe",
+        "model": info.get("model"),
+        "sw_version": info.get("firmware_version"),
+        "connections": {("mac", info.get("mac_address"))},
+        "serial_number": info.get("serial_number"),
+    }
+
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up SleepMe Thermostat binary sensors from a config entry."""
     device_id = entry.data.get("device_id")
     name = entry.data.get("name")
-    coordinator = hass.data[DOMAIN][f"{device_id}_update_manager"]
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry_data["coordinator"]
+    device_info = _device_info(device_id, name, entry_data["device_info"])
 
-    _LOGGER.debug(f"[Device {device_id}] Setting up binary sensor platform from config entry.")
+    async_add_entities(
+        [
+            WaterLevelLowSensor(coordinator, device_id, name, device_info),
+            DeviceConnectedBinarySensor(coordinator, device_id, name, device_info),
+        ]
+    )
 
-    thermostat = hass.data[DOMAIN].get(device_id)
-
-    if thermostat is None:
-        _LOGGER.error(f"[Device {device_id}] Thermostat entity not found!")
-        hass.components.persistent_notification.create(
-            f"The SleepMe Thermostat entity for device {device_id} was not found. Please check the configuration.",
-            title="SleepMe Thermostat Error"
-        )
-        return
-
-    # Create the sensors and add them
-    water_level_sensor = WaterLevelLowSensor(coordinator, thermostat, device_id, name)
-    connected_sensor = DeviceConnectedBinarySensor(coordinator, thermostat, device_id, name)
-
-    async_add_entities([water_level_sensor, connected_sensor])
 
 class WaterLevelLowSensor(CoordinatorEntity, BinarySensorEntity):
-    """Representation of a binary sensor that indicates if the water level is low."""
+    """Binary sensor: water level low."""
 
-    def __init__(self, coordinator, thermostat, device_id, name):
+    _attr_device_class = "problem"
+
+    def __init__(self, coordinator, device_id, name, device_info):
         super().__init__(coordinator)
-        self._thermostat = thermostat
         self._device_id = device_id
         self._attr_name = f"Dock Pro {name} Water Level"
-        self._attr_device_class = "problem"
         self._attr_unique_id = f"{DOMAIN}_{device_id}_water_low"
-
-        # Reuse the device info from the thermostat entity
-        self._attr_device_info = thermostat.device_info
+        self._attr_device_info = device_info
 
     @property
     def is_on(self):
         """Return true if the water level is low."""
         return self.coordinator.data["status"].get("is_water_low")
 
-class DeviceConnectedBinarySensor(CoordinatorEntity, BinarySensorEntity):
-    """Representation of a binary sensor that indicates if the device is connected."""
 
-    def __init__(self, coordinator, thermostat, device_id, name):
+class DeviceConnectedBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Binary sensor: device connectivity."""
+
+    _attr_device_class = "connectivity"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator, device_id, name, device_info):
         super().__init__(coordinator)
-        self._thermostat = thermostat
         self._device_id = device_id
         self._attr_name = f"Dock Pro {name} Connected"
-        self._attr_device_class = "connectivity"
         self._attr_unique_id = f"{DOMAIN}_{device_id}_connected"
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
-
-        # Reuse the device info from the thermostat entity
-        self._attr_device_info = thermostat.device_info
+        self._attr_device_info = device_info
 
     @property
     def is_on(self):

--- a/custom_components/sleepme_thermostat/climate.py
+++ b/custom_components/sleepme_thermostat/climate.py
@@ -26,12 +26,14 @@ async def async_setup_entry(hass, entry, async_add_entities):
     """Set up SleepMe Thermostat climate entity from a config entry."""
     device_id = entry.data.get("device_id")
     name = entry.data.get("name")
-    coordinator = hass.data[DOMAIN][f"{device_id}_update_manager"]
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
-    _LOGGER.debug(f"[Device {device_id}] Setting up SleepMeThermostat entity with name: {name}")
+    _LOGGER.debug(
+        "[Device %s] Setting up SleepMeThermostat entity with name: %s",
+        device_id,
+        name,
+    )
     thermostat = SleepMeThermostat(coordinator, device_id, name, entry.data)
-
-    hass.data[DOMAIN][device_id] = thermostat
     async_add_entities([thermostat])
 
 class SleepMeThermostat(CoordinatorEntity, ClimateEntity):

--- a/custom_components/sleepme_thermostat/config_flow.py
+++ b/custom_components/sleepme_thermostat/config_flow.py
@@ -1,12 +1,25 @@
+"""Config flow for SleepMe Thermostat."""
+
+from __future__ import annotations
+
 import logging
+from typing import Any
+
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.data_entry_flow import FlowResult
+
+from .const import API_URL, DOMAIN
 from .sleepme import SleepMeClient
-from .const import DOMAIN, API_URL
-from httpx import HTTPStatusError
+from .sleepme_api import (
+    SleepMeAuthError,
+    SleepMeConnectionError,
+    SleepMeRateLimited,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
 
 class SleepMeThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for SleepMe Thermostat."""
@@ -14,48 +27,43 @@ class SleepMeThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 3
 
     def __init__(self) -> None:
-        """Initialize the config flow."""
-        self.api_token = ""
-        self.claimed_devices = []
+        self.api_token: str = ""
+        self.claimed_devices: list = []
+        self._reauth_entry: ConfigEntry | None = None
 
     @staticmethod
     def _schema(api_token: str = "") -> vol.Schema:
-        """Return the schema for the current step."""
-        return vol.Schema({
-            vol.Required("api_token", default=api_token): str,
-        })
+        return vol.Schema(
+            {
+                vol.Required("api_token", default=api_token): str,
+            }
+        )
 
     async def async_step_user(self, user_input=None) -> FlowResult:
         """Handle the initial step."""
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
-            _LOGGER.debug(f"User input received: {user_input}")
+            _LOGGER.debug(
+                "User submitted api token (length=%d)",
+                len(user_input.get("api_token", "")),
+            )
             self.api_token = user_input.get("api_token")
 
             client = SleepMeClient(self.hass, API_URL, self.api_token)
 
             try:
                 self.claimed_devices = await client.get_claimed_devices()
-                _LOGGER.debug(f"Claimed devices: {self.claimed_devices}")
-
                 if not self.claimed_devices:
                     errors["base"] = "no_devices_found"
                 else:
                     return await self.async_step_select_device()
-
-            except ValueError as err:
-                if str(err) == "invalid_token":
-                    _LOGGER.error(f"Invalid token error: {err}")
-                    errors["base"] = "invalid_token"
-                else:
-                    _LOGGER.error(f"Unexpected ValueError: {err}")
-                    errors["base"] = "cannot_connect"
-            except HTTPStatusError as e:
-                _LOGGER.error(f"HTTP error fetching claimed devices: {e}")
+            except SleepMeAuthError:
+                errors["base"] = "invalid_token"
+            except (SleepMeRateLimited, SleepMeConnectionError):
                 errors["base"] = "cannot_connect"
-            except Exception as e:
-                _LOGGER.error(f"Unexpected error fetching claimed devices: {e}")
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Unexpected error fetching claimed devices")
                 errors["base"] = "cannot_connect"
 
         return self.async_show_form(
@@ -65,12 +73,10 @@ class SleepMeThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_select_device(self, user_input=None) -> FlowResult:
-        """Step 2: Select a device from the list of claimed devices."""
-        errors = {}
+        """Step 2: select a device from the list of claimed devices."""
+        errors: dict[str, str] = {}
 
         if user_input is not None:
-            _LOGGER.debug(f"Device selected: {user_input}")
-
             device_id = user_input["device_id"]
             name = self.context["claimed_devices_dict"][device_id]
 
@@ -81,8 +87,6 @@ class SleepMeThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             try:
                 device_status = await client.get_device_status()
-                _LOGGER.debug(f"Device status: {device_status}")
-
                 return self.async_create_entry(
                     title=f"Dock Pro {name}",
                     data={
@@ -90,33 +94,77 @@ class SleepMeThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         "api_token": self.api_token,
                         "device_id": device_id,
                         "name": name,
-                        "firmware_version": device_status.get("about", {}).get("firmware_version"),
-                        "mac_address": device_status.get("about", {}).get("mac_address"),
+                        "firmware_version": device_status.get("about", {}).get(
+                            "firmware_version"
+                        ),
+                        "mac_address": device_status.get("about", {}).get(
+                            "mac_address"
+                        ),
                         "model": device_status.get("about", {}).get("model"),
-                        "serial_number": device_status.get("about", {}).get("serial_number"),
+                        "serial_number": device_status.get("about", {}).get(
+                            "serial_number"
+                        ),
                     },
                 )
-
-            except Exception as e:
-                _LOGGER.error(f"Error fetching device status: {e}")
+            except SleepMeAuthError:
+                errors["base"] = "invalid_token"
+            except (SleepMeRateLimited, SleepMeConnectionError):
+                errors["base"] = "cannot_connect"
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Error fetching device status")
                 errors["base"] = "cannot_fetch_device_info"
 
         if self.claimed_devices:
-            claimed_devices_dict = {device["id"]: device["name"] for device in self.claimed_devices}
-            self.context["claimed_devices_dict"] = claimed_devices_dict
+            self.context["claimed_devices_dict"] = {
+                device["id"]: device["name"] for device in self.claimed_devices
+            }
         else:
             errors["base"] = "no_devices_found"
 
-        data_schema = vol.Schema({
-            vol.Required("device_id"): vol.In(self.context["claimed_devices_dict"])
-        })
-
         return self.async_show_form(
             step_id="select_device",
-            data_schema=data_schema,
-            errors=errors
+            data_schema=vol.Schema(
+                {vol.Required("device_id"): vol.In(self.context["claimed_devices_dict"])}
+            ),
+            errors=errors,
         )
 
-    async def async_step_import(self, user_input=None) -> FlowResult:
-        """Handle import from YAML."""
-        return await self.async_step_user(user_input)
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> FlowResult:
+        """Reauth triggered by coordinator raising ConfigEntryAuthFailed."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input=None) -> FlowResult:
+        """Prompt for a new API token and validate it against the API."""
+        errors: dict[str, str] = {}
+        assert self._reauth_entry is not None
+
+        if user_input is not None:
+            new_token = user_input["api_token"]
+            client = SleepMeClient(self.hass, API_URL, new_token)
+            try:
+                claimed = await client.get_claimed_devices()
+                existing_device_id = self._reauth_entry.data["device_id"]
+                if not any(d.get("id") == existing_device_id for d in claimed):
+                    errors["base"] = "device_not_found_for_token"
+                else:
+                    return self.async_update_reload_and_abort(
+                        self._reauth_entry,
+                        data={**self._reauth_entry.data, "api_token": new_token},
+                        reason="reauth_successful",
+                    )
+            except SleepMeAuthError:
+                errors["base"] = "invalid_token"
+            except (SleepMeRateLimited, SleepMeConnectionError):
+                errors["base"] = "cannot_connect"
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Unexpected error during reauth")
+                errors["base"] = "cannot_connect"
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required("api_token"): str}),
+            errors=errors,
+        )

--- a/custom_components/sleepme_thermostat/sensor.py
+++ b/custom_components/sleepme_thermostat/sensor.py
@@ -1,142 +1,159 @@
+"""Diagnostic sensors for SleepMe Dock Pro: IP, LAN, brightness, display unit, time zone."""
+
+from __future__ import annotations
+
 import logging
+
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+
+def _device_info(device_id: str, name: str, info: dict) -> dict:
+    return {
+        "identifiers": {(DOMAIN, device_id)},
+        "name": f"Dock Pro {name}",
+        "manufacturer": "SleepMe",
+        "model": info.get("model"),
+        "sw_version": info.get("firmware_version"),
+        "connections": {("mac", info.get("mac_address"))},
+        "serial_number": info.get("serial_number"),
+    }
+
+
 async def async_setup_entry(hass, entry, async_add_entities):
-    """Set up SleepMe Thermostat sensors from a config entry."""
+    """Set up SleepMe Thermostat diagnostic sensors from a config entry."""
     device_id = entry.data.get("device_id")
     name = entry.data.get("name")
-    coordinator = hass.data[DOMAIN][f"{device_id}_update_manager"]
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry_data["coordinator"]
+    device_info = _device_info(device_id, name, entry_data["device_info"])
 
-    _LOGGER.debug(f"[Device {device_id}] Setting up sensor platform from config entry.")
+    async_add_entities(
+        [
+            IPAddressSensor(coordinator, device_id, name, device_info),
+            LANAddressSensor(coordinator, device_id, name, device_info),
+            BrightnessLevelSensor(coordinator, device_id, name, device_info),
+            DisplayTemperatureUnitSensor(coordinator, device_id, name, device_info),
+            TimeZoneSensor(coordinator, device_id, name, device_info),
+        ]
+    )
 
-    thermostat = hass.data[DOMAIN].get(device_id)
 
-    if thermostat is None:
-        _LOGGER.error(f"[Device {device_id}] Thermostat entity not found!")
-        hass.components.persistent_notification.create(
-            f"The SleepMe Thermostat entity for device {device_id} was not found. Please check the configuration.",
-            title="SleepMe Thermostat Error"
-        )
-        return
+class _SleepMeDiagnosticSensor(CoordinatorEntity, SensorEntity):
+    """Common base for diagnostic sensors."""
 
-    # Create the sensors and add them
-    ip_address_sensor = IPAddressSensor(coordinator, thermostat, device_id, name)
-    lan_address_sensor = LANAddressSensor(coordinator, thermostat, device_id, name)
-    brightness_level_sensor = BrightnessLevelSensor(coordinator, thermostat, device_id, name)
-    display_temp_unit_sensor = DisplayTemperatureUnitSensor(coordinator, thermostat, device_id, name)
-    time_zone_sensor = TimeZoneSensor(coordinator, thermostat, device_id, name)
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    async_add_entities([
-        ip_address_sensor,
-        lan_address_sensor,
-        brightness_level_sensor,
-        display_temp_unit_sensor,
-        time_zone_sensor
-    ])
-
-class IPAddressSensor(CoordinatorEntity, SensorEntity):
-    """Representation of a sensor that indicates the IP address."""
-
-    def __init__(self, coordinator, thermostat, device_id, name):
+    def __init__(self, coordinator, device_id, name, device_info, *, suffix, label):
         super().__init__(coordinator)
-        self._thermostat = thermostat
         self._device_id = device_id
-        self._attr_name = f"Dock Pro {name} IP Address"
-        self._attr_unique_id = f"{DOMAIN}_{device_id}_ip_address"
-        self._attr_icon = "mdi:ip"
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_name = f"Dock Pro {name} {label}"
+        self._attr_unique_id = f"{DOMAIN}_{device_id}_{suffix}"
+        self._attr_device_info = device_info
 
-        # Reuse the device info from the thermostat entity
-        self._attr_device_info = thermostat.device_info
+
+class IPAddressSensor(_SleepMeDiagnosticSensor):
+    """IP address of the device."""
+
+    _attr_icon = "mdi:ip"
+
+    def __init__(self, coordinator, device_id, name, device_info):
+        super().__init__(
+            coordinator,
+            device_id,
+            name,
+            device_info,
+            suffix="ip_address",
+            label="IP Address",
+        )
 
     @property
-    def state(self):
-        """Return the IP address of the device."""
+    def native_value(self):
         return self.coordinator.data["about"].get("ip_address")
 
-class LANAddressSensor(CoordinatorEntity, SensorEntity):
-    """Representation of a sensor that indicates the LAN address."""
 
-    def __init__(self, coordinator, thermostat, device_id, name):
-        super().__init__(coordinator)
-        self._thermostat = thermostat
-        self._device_id = device_id
-        self._attr_name = f"Dock Pro {name} LAN Address"
-        self._attr_unique_id = f"{DOMAIN}_{device_id}_lan_address"
-        self._attr_icon = "mdi:lan"
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+class LANAddressSensor(_SleepMeDiagnosticSensor):
+    """LAN address of the device."""
 
-        # Reuse the device info from the thermostat entity
-        self._attr_device_info = thermostat.device_info
+    _attr_icon = "mdi:lan"
+
+    def __init__(self, coordinator, device_id, name, device_info):
+        super().__init__(
+            coordinator,
+            device_id,
+            name,
+            device_info,
+            suffix="lan_address",
+            label="LAN Address",
+        )
 
     @property
-    def state(self):
-        """Return the LAN address of the device."""
+    def native_value(self):
         return self.coordinator.data["about"].get("lan_address")
 
-class BrightnessLevelSensor(CoordinatorEntity, SensorEntity):
-    """Representation of a sensor that indicates the brightness level."""
 
-    def __init__(self, coordinator, thermostat, device_id, name):
-        super().__init__(coordinator)
-        self._thermostat = thermostat
-        self._device_id = device_id
-        self._attr_name = f"Dock Pro {name} Brightness Level"
-        self._attr_unique_id = f"{DOMAIN}_{device_id}_brightness_level"
-        self._attr_icon = "mdi:brightness-6"
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self._attr_native_unit_of_measurement = "%"  # Set unit to percentage
+class BrightnessLevelSensor(_SleepMeDiagnosticSensor):
+    """Display brightness in percent."""
 
-        # Reuse the device info from the thermostat entity
-        self._attr_device_info = thermostat.device_info
+    _attr_icon = "mdi:brightness-6"
+    _attr_native_unit_of_measurement = "%"
+
+    def __init__(self, coordinator, device_id, name, device_info):
+        super().__init__(
+            coordinator,
+            device_id,
+            name,
+            device_info,
+            suffix="brightness_level",
+            label="Brightness Level",
+        )
 
     @property
-    def state(self):
-        """Return the brightness level of the device."""
+    def native_value(self):
         return self.coordinator.data["control"].get("brightness_level")
 
-class DisplayTemperatureUnitSensor(CoordinatorEntity, SensorEntity):
-    """Representation of a sensor that indicates the display temperature unit."""
 
-    def __init__(self, coordinator, thermostat, device_id, name):
-        super().__init__(coordinator)
-        self._thermostat = thermostat
-        self._device_id = device_id
-        self._attr_name = f"Dock Pro {name} Display Temperature Unit"
-        self._attr_unique_id = f"{DOMAIN}_{device_id}_display_temperature_unit"
-        self._attr_icon = "mdi:thermometer"
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+class DisplayTemperatureUnitSensor(_SleepMeDiagnosticSensor):
+    """Display temperature unit (C / F)."""
 
-        # Reuse the device info from the thermostat entity
-        self._attr_device_info = thermostat.device_info
+    _attr_icon = "mdi:thermometer"
 
-    @property
-    def state(self):
-        """Return the display temperature unit of the device in uppercase."""
-        temp_unit = self.coordinator.data["control"].get("display_temperature_unit")
-        return temp_unit.upper() if temp_unit else None
-
-class TimeZoneSensor(CoordinatorEntity, SensorEntity):
-    """Representation of a sensor that indicates the time zone."""
-
-    def __init__(self, coordinator, thermostat, device_id, name):
-        super().__init__(coordinator)
-        self._thermostat = thermostat
-        self._device_id = device_id
-        self._attr_name = f"Dock Pro {name} Time Zone"
-        self._attr_unique_id = f"{DOMAIN}_{device_id}_time_zone"
-        self._attr_icon = "mdi:earth"
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
-
-        # Reuse the device info from the thermostat entity
-        self._attr_device_info = thermostat.device_info
+    def __init__(self, coordinator, device_id, name, device_info):
+        super().__init__(
+            coordinator,
+            device_id,
+            name,
+            device_info,
+            suffix="display_temperature_unit",
+            label="Display Temperature Unit",
+        )
 
     @property
-    def state(self):
-        """Return the time zone of the device."""
+    def native_value(self):
+        unit = self.coordinator.data["control"].get("display_temperature_unit")
+        return unit.upper() if unit else None
+
+
+class TimeZoneSensor(_SleepMeDiagnosticSensor):
+    """Configured time zone."""
+
+    _attr_icon = "mdi:earth"
+
+    def __init__(self, coordinator, device_id, name, device_info):
+        super().__init__(
+            coordinator,
+            device_id,
+            name,
+            device_info,
+            suffix="time_zone",
+            label="Time Zone",
+        )
+
+    @property
+    def native_value(self):
         return self.coordinator.data["control"].get("time_zone")

--- a/custom_components/sleepme_thermostat/sleepme.py
+++ b/custom_components/sleepme_thermostat/sleepme.py
@@ -1,83 +1,65 @@
+"""High-level SleepMe API client.
+
+Thin wrapper over SleepMeAPI. Raises typed exceptions from sleepme_api on
+failure — does not swallow errors. Callers (coordinator, config_flow,
+climate command path) translate them into HA-framework exceptions.
+"""
+
+from __future__ import annotations
+
 import logging
-from .sleepme_api import SleepMeAPI
+
 from homeassistant.core import HomeAssistant
+
+from .sleepme_api import SleepMeAPI
 
 _LOGGER = logging.getLogger(__name__)
 
-def round_half_up(n):
+
+def round_half_up(n: float) -> float:
     """Round a number to the nearest .0 or .5."""
     return round(n * 2) / 2
 
+
 class SleepMeClient:
-    def __init__(self, hass: HomeAssistant, api_url: str, token: str, device_id: str = None):
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        api_url: str,
+        token: str,
+        device_id: str | None = None,
+    ) -> None:
         self.api_url = api_url
         self.token = token
         self.device_id = device_id
         self.api = SleepMeAPI(hass, api_url, token)
-        _LOGGER.debug(f"[Device {self.device_id}] Initialized SleepMeClient with API URL: {self.api_url}")
 
-    async def set_temp_level(self, temp_c: float, retries: int = 2):
-        """Set the temperature level in Celsius and provide feedback, with retry logic."""
+    async def set_temp_level(self, temp_c: float, retries: int = 2) -> dict:
+        """Set the temperature level in Celsius."""
         temp_c = round_half_up(temp_c)
         endpoint = f"devices/{self.device_id}"
         data = {"set_temperature_c": temp_c}
-        _LOGGER.debug(f"[Device {self.device_id}] Sending request to set temperature to {temp_c}C")
+        return await self.api.api_request("PATCH", endpoint, data=data, retries=retries)
 
-        response = await self.api.api_request("PATCH", endpoint, data=data, retries=retries)
-
-        if not response:
-            _LOGGER.warning(f"Failed to set temperature to {temp_c}C for device {self.device_id}. Received empty response.")
-            return {}
-
-        if response.get("set_temperature_c") == temp_c:
-            _LOGGER.info(f"[Device {self.device_id}] Temperature successfully set to {temp_c}C.")
-
-        return response
-
-    async def set_device_status(self, status: str, retries: int = 2):
-        """Set the device status to either 'active' (on) or 'standby' (off), with retry logic."""
-        if status not in ["active", "standby"]:
+    async def set_device_status(self, status: str, retries: int = 2) -> dict:
+        """Set the device status to 'active' (on) or 'standby' (off)."""
+        if status not in ("active", "standby"):
             raise ValueError("Status must be either 'active' or 'standby'.")
-
         endpoint = f"devices/{self.device_id}"
         data = {"thermal_control_status": status}
-        _LOGGER.debug(f"[Device {self.device_id}] Sending request to set device status to {status}")
+        return await self.api.api_request("PATCH", endpoint, data=data, retries=retries)
 
-        response = await self.api.api_request("PATCH", endpoint, data=data, retries=retries)
-
-        if not response:
-            _LOGGER.warning(f"Failed to set device status to {status} for device {self.device_id}. Received empty response.")
-            return {}
-
-        if response.get("thermal_control_status") == status:
-            _LOGGER.info(f"[Device {self.device_id}] Device status successfully set to {status}.")
-
+    async def get_claimed_devices(self, retries: int = 1) -> list:
+        """Return a list of claimed devices for the configured token."""
+        response = await self.api.api_request("GET", "devices", retries=retries)
+        if not isinstance(response, list):
+            raise ValueError(f"unexpected response for claimed devices: {response!r}")
         return response
 
-    async def get_claimed_devices(self, retries: int = 1):
-        """Return a list of claimed devices for the given token, with retry logic."""
-        endpoint = "devices"
-        _LOGGER.debug(f"[Device {self.device_id}] Fetching claimed devices from {endpoint}")
-
-        response = await self.api.api_request("GET", endpoint, retries=retries)
-
-        if isinstance(response, list):
-            _LOGGER.info(f"Successfully fetched claimed devices: {response}")
-            return response
-
-        _LOGGER.error(f"Unexpected response format for claimed devices: {response}")
-        return []
-
-    async def get_device_status(self, retries: int = 0):
-        """Retrieve the device status, with retry logic."""
+    async def get_device_status(self, retries: int = 0) -> dict:
+        """Retrieve the device status."""
         endpoint = f"devices/{self.device_id}"
-        _LOGGER.debug(f"[Device {self.device_id}] Fetching device status from {endpoint}")
-
         response = await self.api.api_request("GET", endpoint, retries=retries)
-
-        if isinstance(response, dict):
-            _LOGGER.debug(f"[Device {self.device_id}] Device status: {response}")
-            return response
-
-        _LOGGER.error(f"Failed to fetch device status for {self.device_id}. Response: {response}")
-        return {}
+        if not isinstance(response, dict):
+            raise ValueError(f"unexpected response for device status: {response!r}")
+        return response

--- a/custom_components/sleepme_thermostat/sleepme_api.py
+++ b/custom_components/sleepme_thermostat/sleepme_api.py
@@ -1,108 +1,239 @@
+"""HTTP transport for the SleepMe developer API.
+
+Responsibilities:
+- Authorize requests with bearer token.
+- Rate-limit locally (sliding window, concurrency-safe via instance lock).
+- Retry on 429 + 5xx with monotonically increasing backoff, honoring Retry-After.
+- Surface auth failures (401/403) and connection failures as typed exceptions.
+
+Does NOT:
+- Queue requests when the local rate limiter would block. Raises
+  SleepMeRateLimited; caller (coordinator, config flow, climate path) decides.
+- Manage its own httpx client lifecycle. The client is HA's shared instance,
+  obtained via get_async_client(hass).
+
+If the server asks us to wait (Retry-After), we honor that inside api_request.
+While that sleep is in progress the local deque is not cleared, so a concurrent
+caller can still trip SleepMeRateLimited — which is the desired behavior:
+the server is asking us to back off, so we should locally back off too.
+"""
+
+from __future__ import annotations
+
 import asyncio
-import httpx
 import logging
 import time
-from homeassistant.helpers.httpx_client import get_async_client
-from homeassistant.core import HomeAssistant
 from collections import deque
+from email.utils import parsedate_to_datetime
+
+import httpx
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.httpx_client import get_async_client
 
 _LOGGER = logging.getLogger(__name__)
 
+MAX_REQUESTS_PER_MINUTE = 9
+RATE_LIMIT_WINDOW = 60  # seconds
+DEFAULT_RETRIES = 3
+BACKOFF_BASE_429 = 30  # seconds
+BACKOFF_BASE_5XX = 10  # seconds
+BACKOFF_BASE_TIMEOUT = 10  # seconds
+BACKOFF_CEILING = 600  # seconds (10 min); Retry-After may exceed this and we honor it anyway.
+
+
+class SleepMeAPIError(Exception):
+    """Base for typed transport errors."""
+
+
+class SleepMeAuthError(SleepMeAPIError):
+    """401/403 from the API. Coordinator should raise ConfigEntryAuthFailed."""
+
+
+class SleepMeRateLimited(SleepMeAPIError):
+    """Local rate-limiter would have blocked the request. Caller decides retry."""
+
+
+class SleepMeConnectionError(SleepMeAPIError):
+    """Network-level failure (DNS, refused, timeout). Coordinator should raise UpdateFailed."""
+
+
 class SleepMeAPI:
-    def __init__(self, hass: HomeAssistant, api_url: str, token: str, max_requests_per_minute=9):
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        api_url: str,
+        token: str,
+        max_requests_per_minute: int = MAX_REQUESTS_PER_MINUTE,
+    ) -> None:
         self.api_url = api_url
         self.token = token
         self.client = get_async_client(hass)
-        self.request_times = deque(maxlen=max_requests_per_minute)
-        self.rate_limit_interval = 60  # seconds
+        self._request_times: deque[float] = deque(maxlen=max_requests_per_minute)
+        self._lock = asyncio.Lock()
 
-    async def api_request(self, method: str, endpoint: str, params=None, data=None, input_headers=None, retries=3):
-        """Handles rate limiting, retries, and calls perform_request."""
-        request_id = f"{method.upper()}-{endpoint}-{int(time.time())}"
-        _LOGGER.debug(f"[{request_id}] Starting API request with {retries} retries remaining.")
+    # No close() — the httpx client is HA's shared instance and we must not close it.
 
-        async with asyncio.Lock():
-            current_time = time.time()
+    async def api_request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        params: dict | None = None,
+        data: dict | None = None,
+        input_headers: dict | None = None,
+        retries: int = DEFAULT_RETRIES,
+    ):
+        """Send one request with retry-on-transient-error.
 
-            # Rate limiting logic
-            if len(self.request_times) == self.request_times.maxlen and current_time - self.request_times[0] < self.rate_limit_interval:
-                wait_time = self.rate_limit_interval - (current_time - self.request_times[0])
+        Raises:
+            SleepMeAuthError: on 401/403.
+            SleepMeRateLimited: if local rate limiter would block (no queueing).
+            SleepMeConnectionError: on network failure or timeout exhaustion.
+            httpx.HTTPStatusError: on non-retriable HTTP errors after retries exhausted.
+        """
+        attempt = 1
+        while True:
+            await self._enforce_local_rate_limit(method, endpoint)
+            try:
+                return await self._perform_request(
+                    method,
+                    endpoint,
+                    params=params,
+                    data=data,
+                    input_headers=input_headers,
+                )
+            except httpx.HTTPStatusError as err:
+                status = err.response.status_code
+                if status in (401, 403):
+                    raise SleepMeAuthError(f"{status} from {endpoint}") from err
+                if status == 429 and attempt <= retries:
+                    backoff = self._compute_backoff(
+                        BACKOFF_BASE_429, attempt, err.response
+                    )
+                    _LOGGER.warning(
+                        "429 on %s %s; attempt %d/%d, sleeping %.1fs",
+                        method,
+                        endpoint,
+                        attempt,
+                        retries,
+                        backoff,
+                    )
+                    await asyncio.sleep(backoff)
+                    attempt += 1
+                    continue
+                if status in (500, 502, 503, 504) and attempt <= retries:
+                    backoff = self._compute_backoff(
+                        BACKOFF_BASE_5XX, attempt, err.response
+                    )
+                    _LOGGER.warning(
+                        "HTTP %d on %s %s; attempt %d/%d, sleeping %.1fs",
+                        status,
+                        method,
+                        endpoint,
+                        attempt,
+                        retries,
+                        backoff,
+                    )
+                    await asyncio.sleep(backoff)
+                    attempt += 1
+                    continue
+                # Non-retriable / out of retries: re-raise.
+                raise
+            except httpx.TimeoutException as err:
+                if attempt > retries:
+                    raise SleepMeConnectionError(f"timeout on {endpoint}") from err
+                backoff = min(
+                    BACKOFF_BASE_TIMEOUT * (2 ** (attempt - 1)), BACKOFF_CEILING
+                )
+                _LOGGER.warning(
+                    "Timeout on %s %s; attempt %d/%d, sleeping %.1fs",
+                    method,
+                    endpoint,
+                    attempt,
+                    retries,
+                    backoff,
+                )
+                await asyncio.sleep(backoff)
+                attempt += 1
+            except httpx.RequestError as err:
+                # DNS, connection refused, etc. Not worth retrying in-call;
+                # coordinator's next poll will retry.
+                raise SleepMeConnectionError(
+                    f"request error on {endpoint}: {err}"
+                ) from err
 
-                if method.upper() == "GET":
-                    _LOGGER.warning(f"[{request_id}] Rate limiting active. Discarding GET request to {endpoint} instead of delaying by {wait_time:.2f} seconds.")
-                    return {}  # Discard the GET request and return an empty dictionary
+    async def _enforce_local_rate_limit(self, method: str, endpoint: str) -> None:
+        """Record the request or raise SleepMeRateLimited.
 
-                _LOGGER.debug(f"[{request_id}] Rate limiting: waiting for {wait_time:.2f} seconds before making {method.upper()} request to {endpoint}.")
-                await asyncio.sleep(wait_time)
+        Sliding window: drop entries older than RATE_LIMIT_WINDOW, then check
+        capacity. We deliberately do NOT queue — caller decides what to do.
+        """
+        async with self._lock:
+            now = time.monotonic()
+            while (
+                self._request_times
+                and now - self._request_times[0] >= RATE_LIMIT_WINDOW
+            ):
+                self._request_times.popleft()
 
-            # Add the current time to the deque
-            self.request_times.append(current_time)
+            if len(self._request_times) >= self._request_times.maxlen:
+                wait = RATE_LIMIT_WINDOW - (now - self._request_times[0])
+                _LOGGER.warning(
+                    "Local rate limit hit on %s %s; would need %.1fs. Rejecting.",
+                    method,
+                    endpoint,
+                    wait,
+                )
+                raise SleepMeRateLimited(
+                    f"{method} {endpoint}: local rate-limiter at capacity"
+                )
 
-        # Perform the API request
-        try:
-            result = await self.perform_request(method, endpoint, params=params, data=data, input_headers=input_headers)
-            _LOGGER.debug(f"[{request_id}] API request successful.")
-            return result
-        except Exception as e:
-            _LOGGER.debug(f"[{request_id}] Exception occurred: {e}. Passing to handle_error.")
-            return await self.handle_error(e, method, endpoint, params, data, input_headers, retries)
+            self._request_times.append(now)
 
-    async def perform_request(self, method: str, endpoint: str, params=None, data=None, input_headers=None):
-        """Executes the actual API request."""
-        request_id = f"{method.upper()}-{endpoint}-{int(time.time())}"
-        headers = input_headers or {}
+    async def _perform_request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        params: dict | None,
+        data: dict | None,
+        input_headers: dict | None,
+    ):
+        headers = dict(input_headers or {})
         headers["Authorization"] = f"Bearer {self.token}"
-
-        _LOGGER.debug(f"[{request_id}] Making {method.upper()} request to {self.api_url}/{endpoint} with params: {params} and data: {data}")
-        response = await self.client.request(method, f"{self.api_url}/{endpoint}", headers=headers, json=data, params=params)
+        _LOGGER.debug(
+            "%s %s/%s params=%s data=%s",
+            method,
+            self.api_url,
+            endpoint,
+            params,
+            data,
+        )
+        response = await self.client.request(
+            method,
+            f"{self.api_url}/{endpoint}",
+            headers=headers,
+            json=data,
+            params=params,
+        )
         response.raise_for_status()
-        _LOGGER.debug(f"[{request_id}] Request to {endpoint} completed successfully with status {response.status_code}.")
-        return response.json()  # Process and return the JSON response
+        return response.json()
 
-    async def handle_error(self, error, method: str, endpoint: str, params=None, data=None, input_headers=None, retries=3):
-        """Classifies errors and applies backoff before retrying if necessary."""
-        request_id = f"{method.upper()}-{endpoint}-{int(time.time())}"
+    @staticmethod
+    def _compute_backoff(base: int, attempt: int, response: httpx.Response) -> float:
+        """Resolve backoff seconds.
 
-        if retries <= 0:
-            _LOGGER.debug(f"[{request_id}] API request to {endpoint} failed after all retries.")
-            return {}  # Return an empty dictionary on failure
-
-        _LOGGER.warning(f"[{request_id}] Handling error: {error}. Retries remaining: {retries}")
-
-        # Determine backoff time based on error type
-        if isinstance(error, httpx.HTTPStatusError):
-            if error.response.status_code == 403:
-                _LOGGER.debug(f"[{request_id}] Invalid API token. Received 403 Forbidden for {self.api_url}/{endpoint}.")
-                raise ValueError("invalid_token")
-            elif error.response.status_code == 429:
-                # Backoff times: 30, 60, 120, 240... seconds for 429 errors
-                initial_backoff = 30
-                _LOGGER.warning(f"[{request_id}] 429 Too Many Requests. Applying backoff starting at {initial_backoff} seconds.")
-            elif error.response.status_code in {500, 502, 503, 504}:
-                # Backoff times: 10, 20, 40, 80... seconds for server errors
-                initial_backoff = 10
-                _LOGGER.warning(f"[{request_id}] Server error {error.response.status_code}. Applying backoff starting at {initial_backoff} seconds.")
-            else:
-                _LOGGER.debug(f"[{request_id}] HTTP error {error.response.status_code}. No retry configured.")
-                raise ValueError("cannot_connect")
-        elif isinstance(error, httpx.TimeoutException):
-            # Backoff times: 10, 20, 40, 80... seconds for timeouts
-            initial_backoff = 10
-            _LOGGER.warning(f"[{request_id}] Timeout occurred. Applying backoff starting at {initial_backoff} seconds.")
-        elif isinstance(error, httpx.RequestError):
-            _LOGGER.debug(f"[{request_id}] Request error: {error}. Cannot connect.")
-            raise ValueError("cannot_connect")
-
-        backoff_time = initial_backoff * (2 ** (retries - 1))
-        _LOGGER.warning(f"[{request_id}] Retrying after {backoff_time} seconds. Retries left: {retries-1}")
-
-        await asyncio.sleep(backoff_time)
-
-        # Retry the API request with one less retry
-        return await self.api_request(method, endpoint, params=params, data=data, input_headers=input_headers, retries=retries-1)
-
-    async def close(self):
-        """Close the httpx client."""
-        _LOGGER.debug("Closing HTTP client...")
-        await self.client.aclose()
-        _LOGGER.debug("HTTP client closed.")
+        Honors Retry-After (integer seconds or HTTP-date). Falls back to
+        base * 2**(attempt-1), capped at BACKOFF_CEILING.
+        """
+        ra = response.headers.get("Retry-After")
+        if ra:
+            try:
+                return float(int(ra))
+            except ValueError:
+                try:
+                    target = parsedate_to_datetime(ra).timestamp()
+                    return max(0.0, target - time.time())
+                except (TypeError, ValueError):
+                    _LOGGER.debug("Unparsable Retry-After: %r", ra)
+        return min(base * (2 ** (attempt - 1)), BACKOFF_CEILING)

--- a/custom_components/sleepme_thermostat/translations/en.json
+++ b/custom_components/sleepme_thermostat/translations/en.json
@@ -21,16 +21,28 @@
         "data_description": {
           "device_id": "Choose one of the devices discovered."
         }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate SleepMe Dock Pro",
+        "description": "Your SleepMe API token is no longer valid. Enter a new token to reconnect.",
+        "data": {
+          "api_token": "API Token"
+        },
+        "data_description": {
+          "api_token": "Paste a fresh token generated in the SleepMe Developer API section."
+        }
       }
     },
     "error": {
       "invalid_token": "Invalid API token, please try again.",
       "cannot_connect": "Failed to connect to the SleepMe API.",
       "no_devices_found": "No devices found for this API token.",
-      "cannot_fetch_device_info": "Unable to fetch device information."
+      "cannot_fetch_device_info": "Unable to fetch device information.",
+      "device_not_found_for_token": "This token does not have access to the originally configured device."
     },
     "abort": {
-      "already_configured": "This device is already configured."
+      "already_configured": "This device is already configured.",
+      "reauth_successful": "Re-authentication was successful."
     }
   }
 }

--- a/custom_components/sleepme_thermostat/translations/es.json
+++ b/custom_components/sleepme_thermostat/translations/es.json
@@ -15,16 +15,25 @@
         "data": {
           "device_id": "ID del Dispositivo"
         }
+      },
+      "reauth_confirm": {
+        "title": "Re-autenticar SleepMe Dock Pro",
+        "description": "Su token de API de SleepMe ya no es válido. Ingrese un nuevo token para volver a conectarse.",
+        "data": {
+          "api_token": "Token de API"
+        }
       }
     },
     "error": {
       "invalid_token": "Token API inválido, por favor intente nuevamente.",
       "cannot_connect": "No se pudo conectar a la API. Por favor, verifique el token e intente nuevamente.",
       "no_devices_found": "No se encontraron dispositivos con el token proporcionado.",
-      "cannot_fetch_device_info": "No se puede obtener la información del dispositivo. Por favor, verifique su conexión e intente nuevamente."
+      "cannot_fetch_device_info": "No se puede obtener la información del dispositivo. Por favor, verifique su conexión e intente nuevamente.",
+      "device_not_found_for_token": "Este token no tiene acceso al dispositivo configurado originalmente."
+    },
+    "abort": {
+      "already_configured": "Este dispositivo ya está configurado.",
+      "reauth_successful": "La re-autenticación fue exitosa."
     }
-  },
-  "abort": {
-    "already_configured": "Este dispositivo ya está configurado."
   }
 }

--- a/custom_components/sleepme_thermostat/update_manager.py
+++ b/custom_components/sleepme_thermostat/update_manager.py
@@ -1,60 +1,77 @@
+"""DataUpdateCoordinator for SleepMe devices.
+
+Translates transport-layer typed exceptions into HA framework exceptions:
+- 401/403 (SleepMeAuthError) -> ConfigEntryAuthFailed (triggers reauth flow)
+- transient/rate-limit/connection -> UpdateFailed (HA backs off polling)
+
+No stale-data fallback: if a poll fails, HA's framework handles the entity
+availability semantics (CoordinatorEntity flips to unavailable until the next
+successful update).
+"""
+
+from __future__ import annotations
+
 import logging
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from homeassistant.core import HomeAssistant
 from datetime import timedelta
+
+import httpx
+from homeassistant.config_entries import ConfigEntryAuthFailed
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
 from .sleepme import SleepMeClient
+from .sleepme_api import (
+    SleepMeAuthError,
+    SleepMeConnectionError,
+    SleepMeRateLimited,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
-class SleepMeUpdateManager(DataUpdateCoordinator):
-    """Manages data updates for SleepMe devices."""
 
-    def __init__(self, hass: HomeAssistant, api_url: str, token: str, device_id: str):
+class SleepMeUpdateManager(DataUpdateCoordinator):
+    """Manages data updates for a single SleepMe device."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        api_url: str,
+        token: str,
+        device_id: str,
+    ) -> None:
         self.client = SleepMeClient(hass, api_url, token, device_id)
         self.device_id = device_id
-
-        # Initialize the last known good status as None
-        self._last_valid_status = None
-
-        # Set the update interval to 20 seconds
-        update_interval = timedelta(seconds=20)
-
         super().__init__(
             hass,
             _LOGGER,
             name=f"SleepMe Update Manager {device_id}",
-            update_interval=update_interval,
+            update_interval=timedelta(seconds=20),
         )
 
-    async def _async_update_data(self):
-        """Fetch the latest data from the SleepMe API."""
+    async def _async_update_data(self) -> dict:
+        """Fetch the latest device status. Raise typed framework exceptions on failure."""
         try:
-            # Fetch device status from the API
             device_status = await self.client.get_device_status()
+        except SleepMeAuthError as err:
+            raise ConfigEntryAuthFailed(
+                "Invalid or revoked SleepMe API token"
+            ) from err
+        except SleepMeRateLimited as err:
+            raise UpdateFailed(
+                "SleepMe API rate-limited; will retry next interval"
+            ) from err
+        except SleepMeConnectionError as err:
+            raise UpdateFailed(f"Cannot reach SleepMe API: {err}") from err
+        except httpx.HTTPStatusError as err:
+            # Non-401/403/429/5xx HTTP errors that transport let through.
+            raise UpdateFailed(
+                f"HTTP {err.response.status_code} from SleepMe API"
+            ) from err
+        except ValueError as err:
+            raise UpdateFailed(str(err)) from err
 
-            # If the device status is empty, return the last valid status
-            if not device_status:
-                _LOGGER.warning(f"Using last valid status for device {self.device_id} due to empty or failed update.")
-                return self._last_valid_status or {
-                    "status": {},
-                    "control": {},
-                    "about": {},
-                }
-
-            # Cache the current valid status
-            self._last_valid_status = {
-                "status": device_status.get("status", {}),
-                "control": device_status.get("control", {}),
-                "about": device_status.get("about", {}),
-            }
-
-            return self._last_valid_status
-
-        except Exception as e:
-            _LOGGER.error(f"Error updating device data for {self.device_id}: {e}")
-            # If an error occurs, return the last valid status
-            return self._last_valid_status or {
-                "status": {},
-                "control": {},
-                "about": {},
-            }
+        return {
+            "status": device_status.get("status", {}),
+            "control": device_status.get("control", {}),
+            "about": device_status.get("about", {}),
+        }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -68,7 +68,7 @@ Set the scaffolding so every subsequent phase ships with tests, lint, and CI. **
 
 ### Phase 1 — P0 fixes
 
-The blocking-correctness pass. Detailed plan: `docs/phase-1-p0-fixes.md` (to be generated via Plan agent before execution).
+The blocking-correctness pass. **Detailed plan: [`phase-1-p0-fixes.md`](./phase-1-p0-fixes.md).**
 
 | Status | Item | Audit ref |
 |--------|------|-----------|

--- a/docs/phase-1-p0-fixes.md
+++ b/docs/phase-1-p0-fixes.md
@@ -1,0 +1,761 @@
+# Phase 1 — P0 Fixes Plan
+
+**Status:** Drafted 2026-05-16, awaiting maintainer approval before execution.
+**Companion docs:** [`AUDIT.md`](./AUDIT.md), [`ROADMAP.md`](./ROADMAP.md), [`phase-0-foundation.md`](./phase-0-foundation.md).
+
+## Goal
+
+Close every P0 audit finding (#1–#9, plus the related #26 close-method removal) in a single focused PR. After this phase:
+
+1. The integration loads, reloads, and unloads cleanly on the live HA host.
+2. Two SleepMe devices can be configured side-by-side without clobbering each other.
+3. A rotated/invalidated API token surfaces as a user-actionable reauth prompt rather than silent stale data.
+4. The transport layer behaves correctly under 429s (honors `Retry-After`, monotonically increasing backoff, no `UnboundLocalError`, no concurrency races).
+5. The coordinator participates in HA's standard error/auth lifecycle (`UpdateFailed`, `ConfigEntryAuthFailed`) instead of swallowing exceptions and serving stale data forever.
+6. The Phase 0 `xfail` regression trap (unload test) flips to a real pass, and the `expected_lingering_timers` fixture is removed.
+
+Phase 1 explicitly does NOT touch `climate.py`'s verify-after-command loop (Phase 3), sensor `state→native_value` migration (Phase 2), options flow (Phase 2), or `strings.json` migration (Phase 2).
+
+## Scope
+
+| Audit # | File | Change |
+|---|---|---|
+| 1  | `__init__.py`      | Remove `_LOGGER.debug(f"API Token: {api_token}")`; redact any other secret-shaped log lines. |
+| 2  | `sleepme_api.py`   | Move `asyncio.Lock()` to `__init__`; guard deque mutation and rate-limit wait correctly. |
+| 3  | `sleepme_api.py`   | Track explicit attempt counter; backoff = `base * 2**(attempt-1)`; honor `Retry-After` on 429. |
+| 4  | `sleepme_api.py`   | `initial_backoff` must be defined on every path that reaches `await asyncio.sleep(backoff_time)`. |
+| 5  | `sleepme_api.py`   | GET-under-rate-limit: **raise `SleepMeRateLimited`**; do not silently return `{}`, do not queue. |
+| 6  | `update_manager.py`| Raise `UpdateFailed` on transient errors; raise `ConfigEntryAuthFailed` on 401/403. Drop the silent last-good-status fallback. |
+| 7  | `__init__.py`      | Add `async_unload_entry`; tear down coordinator + clear `hass.data[DOMAIN][entry.entry_id]`. |
+| 8  | `__init__.py` + all platforms | Key `hass.data[DOMAIN]` by `entry.entry_id`; update every read site in `climate.py`, `binary_sensor.py`, `sensor.py`. |
+| 9  | `config_flow.py`   | Add `async_step_reauth` + `async_step_reauth_confirm`; update entry data via `async_update_reload_and_abort`. |
+| 26 | `sleepme_api.py`   | Delete `SleepMeAPI.close()` — `client` is HA's shared httpx instance. |
+| —  | `tests/test_init.py`, `tests/conftest.py` | Flip unload `xfail` → pass; delete `expected_lingering_timers` fixture. |
+| —  | `tests/`           | Add regression tests for reauth flow, coordinator auth-failure path, transport backoff/`Retry-After`. |
+
+## Deliverables
+
+### 1. Token-leak fix
+
+**File:** `custom_components/sleepme_thermostat/__init__.py`
+
+Drop these lines outright (lines 33–39):
+
+```python
+_LOGGER.debug(f"API URL: {api_url}")
+_LOGGER.debug(f"API Token: {api_token}")
+_LOGGER.debug(f"Device ID: {device_id}")
+_LOGGER.debug(f"Firmware Version: {firmware_version}")
+_LOGGER.debug(f"MAC Address: {mac_address}")
+_LOGGER.debug(f"Model: {model}")
+_LOGGER.debug(f"Serial Number: {serial_number}")
+```
+
+Replace with one line that logs *only* what's safe and useful:
+
+```python
+_LOGGER.debug(
+    "Setting up entry %s for device %s (model=%s, fw=%s)",
+    entry.entry_id, device_id, model, firmware_version,
+)
+```
+
+Also audit:
+- `sleepme_api.py:56` logs `params` and `data` — `data` for a PATCH does NOT contain the token (it contains setpoint/status). Token only appears in `headers["Authorization"]`. Keep `params`/`data` logs (useful for debugging), do not log `headers`.
+- `config_flow.py:33` — `_LOGGER.debug(f"User input received: {user_input}")` logs the token from the form schema. Replace with `_LOGGER.debug("User submitted api token (length=%d)", len(user_input.get("api_token", "")))`.
+
+**Diff shape:** ~10 lines removed, ~3 lines added in `__init__.py`; ~1 line changed in `config_flow.py`. No new files.
+
+**API-budget impact:** none.
+
+---
+
+### 2. `async_unload_entry` + entry_id-keyed `hass.data`
+
+**File:** `custom_components/sleepme_thermostat/__init__.py`
+
+**Current storage shape (broken for multi-device):**
+```python
+hass.data[DOMAIN]["sleepme_controller"] = sleepme_controller       # global; clobbered
+hass.data[DOMAIN][f"{device_id}_update_manager"] = update_manager  # per-device, OK
+hass.data[DOMAIN]["device_info"] = {...}                           # global; clobbered
+hass.data[DOMAIN][device_id] = thermostat                          # set in climate.py
+```
+
+**New storage shape:**
+```python
+hass.data[DOMAIN][entry.entry_id] = {
+    "client": SleepMeClient,
+    "coordinator": SleepMeUpdateManager,
+    "device_info": {...},   # firmware_version, mac_address, model, serial_number
+}
+```
+
+The per-platform `hass.data[DOMAIN][device_id] = thermostat` cross-platform handle goes away in Phase 2 (audit #10). For Phase 1, *do not* introduce it under `entry.entry_id` — the binary_sensor/sensor platforms can read `device_info` directly from the dict.
+
+**Paste-ready `async_setup_entry`:**
+
+```python
+PLATFORMS = ["climate", "binary_sensor", "sensor"]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up SleepMe Thermostat from a config entry."""
+    api_url    = entry.data.get("api_url") or API_URL
+    api_token  = entry.data["api_token"]
+    device_id  = entry.data["device_id"]
+
+    if not api_token or not device_id:
+        raise ConfigEntryNotReady("API token or device ID missing from entry data")
+
+    client = SleepMeClient(hass, api_url, api_token, device_id)
+    coordinator = SleepMeUpdateManager(hass, api_url, api_token, device_id)
+
+    # First refresh - propagates ConfigEntryAuthFailed / ConfigEntryNotReady.
+    await coordinator.async_config_entry_first_refresh()
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "client": client,
+        "coordinator": coordinator,
+        "device_info": {
+            "firmware_version": entry.data.get("firmware_version"),
+            "mac_address":      entry.data.get("mac_address"),
+            "model":            entry.data.get("model"),
+            "serial_number":    entry.data.get("serial_number"),
+        },
+    }
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    _LOGGER.debug("Entry %s set up for device %s", entry.entry_id, device_id)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unloaded:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+    return unloaded
+```
+
+Notes:
+- `coordinator.async_config_entry_first_refresh()` is what makes `ConfigEntryAuthFailed` from `_async_update_data` propagate as a reauth trigger; no extra plumbing needed in `__init__.py`.
+- The `return False` on missing data is upgraded to `raise ConfigEntryNotReady` (audit #19) — small enough to ride along here; it's required anyway for `async_config_entry_first_refresh` semantics.
+- The `coordinator`'s `DataUpdateCoordinator` base class handles its own polling-timer teardown when `async_unload_platforms` succeeds; we do not need to manually cancel `coordinator._unsub_refresh`.
+
+**Cross-platform read sites (audit #8 fan-out):**
+
+| File | Current | New |
+|---|---|---|
+| `climate.py:29`         | `coordinator = hass.data[DOMAIN][f"{device_id}_update_manager"]` | `coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]` |
+| `climate.py:34`         | `hass.data[DOMAIN][device_id] = thermostat` | **delete this line** — `binary_sensor.py` and `sensor.py` get `device_info` from `entry.data` instead (see below). |
+| `binary_sensor.py:13`   | `coordinator = hass.data[DOMAIN][f"{device_id}_update_manager"]` | `coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]` |
+| `binary_sensor.py:17–25`| `thermostat = hass.data[DOMAIN].get(device_id); …persistent_notification.create…` | **delete this whole block.** Build a local `device_info` dict from `hass.data[DOMAIN][entry.entry_id]["device_info"]` and pass to the entity constructors directly. |
+| `binary_sensor.py:45,65`| `self._attr_device_info = thermostat.device_info` | `self._attr_device_info = build_device_info(device_id, name, device_info_dict)` — a small helper. (The longer audit #10 cleanup — full `device_info` rebuild per platform — stays Phase 2. For Phase 1, only enough to get rid of the cross-platform handle.) |
+| `sensor.py:13,17–25,55,75,96,116,137` | Same pattern as `binary_sensor.py`. | Same fix. |
+
+A pragmatic compromise: keep the existing `thermostat.device_info` shape, but build that dict inside binary_sensor / sensor from `entry.data` + the stored `device_info` dict, not by reaching into the climate entity. New helper at the top of each platform:
+
+```python
+def _device_info(device_id: str, name: str, info: dict) -> dict:
+    return {
+        "identifiers": {(DOMAIN, device_id)},
+        "name": f"Dock Pro {name}",
+        "manufacturer": "SleepMe",
+        "model": info.get("model"),
+        "sw_version": info.get("firmware_version"),
+        "connections": {("mac", info.get("mac_address"))},
+        "serial_number": info.get("serial_number"),
+    }
+```
+
+Yes, this duplicates the same helper across three platforms in Phase 1. Phase 2 (audit #10/#22) deduplicates. The cost of doing it once now and dedup-later is lower than the cost of building a shared utility in the same PR as the storage-shape change.
+
+**Diff shape:** `__init__.py` ~30 lines added / ~20 removed (net +10). `climate.py` ~3 lines changed. `binary_sensor.py` ~15 lines changed (deletion + helper). `sensor.py` ~25 lines changed (5 entity classes × 5 lines each, mostly mechanical).
+
+**API-budget impact:** none.
+
+---
+
+### 3. Coordinator: `UpdateFailed` + `ConfigEntryAuthFailed`
+
+**File:** `custom_components/sleepme_thermostat/update_manager.py`
+
+**Current behavior:** swallows every exception, falls back to `_last_valid_status`, returns `{}` on cold start. The entity stays "available," shows stale data, never tells the user anything is wrong.
+
+**New behavior:** let HA's framework manage backoff and reauth. The coordinator's only job is fetch-or-fail-loudly.
+
+**Paste-ready `_async_update_data`:**
+
+```python
+import httpx
+from homeassistant.config_entries import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+
+class SleepMeUpdateManager(DataUpdateCoordinator):
+    """Manages data updates for SleepMe devices."""
+
+    def __init__(self, hass, api_url, token, device_id):
+        self.client = SleepMeClient(hass, api_url, token, device_id)
+        self.device_id = device_id
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"SleepMe Update Manager {device_id}",
+            update_interval=timedelta(seconds=20),
+        )
+
+    async def _async_update_data(self) -> dict:
+        try:
+            device_status = await self.client.get_device_status()
+        except httpx.HTTPStatusError as err:
+            if err.response.status_code in (401, 403):
+                raise ConfigEntryAuthFailed("Invalid or revoked SleepMe token") from err
+            raise UpdateFailed(f"HTTP {err.response.status_code} from SleepMe API") from err
+        except (httpx.RequestError, httpx.TimeoutException) as err:
+            raise UpdateFailed(f"Cannot reach SleepMe API: {err}") from err
+        except SleepMeRateLimited as err:
+            # See deliverable 4. Transport raised this; HA backs off next interval.
+            raise UpdateFailed("SleepMe API rate-limited; will retry next interval") from err
+        except ValueError as err:
+            # SleepMeAPI.handle_error currently raises ValueError("invalid_token") and
+            # ValueError("cannot_connect"). Map them.
+            if str(err) == "invalid_token":
+                raise ConfigEntryAuthFailed("Invalid SleepMe token") from err
+            raise UpdateFailed(str(err)) from err
+
+        if not device_status:
+            # After deliverable 4, an empty dict from the client should be impossible;
+            # keep one defensive line anyway.
+            raise UpdateFailed("Empty device status from SleepMe API")
+
+        return {
+            "status":  device_status.get("status", {}),
+            "control": device_status.get("control", {}),
+            "about":   device_status.get("about", {}),
+        }
+```
+
+Drop `self._last_valid_status` entirely — the framework's `coordinator.last_update_success` + `coordinator.data` already give every consumer the right thing. Stale-data fallback was the root cause of "the integration looks healthy but nothing actually works."
+
+Two upstream consequences that the coordinator can trust:
+- `sleepme.py:get_device_status()` currently silently returns `{}` on unexpected response shapes. Tighten it: raise `UpdateFailed`-bait (e.g. let the underlying exception propagate). Concretely: change `if isinstance(response, dict): return response` else `return {}` to `if isinstance(response, dict): return response` else `raise ValueError(f"unexpected response: {response!r}")`.
+- `sleepme.py:set_temp_level()` and `set_device_status()` are called from `climate.py`, not the coordinator. Phase 1 leaves their behavior alone (silent `{}` on empty response); Phase 3 reworks the climate command path entirely.
+
+**Diff shape:** `update_manager.py` ~25 lines changed (mostly net negative). `sleepme.py` ~3 lines changed in `get_device_status`.
+
+**API-budget impact:**
+- **Per-minute idle:** unchanged. Coordinator still polls every 20s.
+- **429 behavior:** *better.* Today's swallow-and-return-stale means the coordinator runs the next poll on schedule, hitting the rate limiter again; combined with the broken backoff inside the transport, this produces cascading 429s. With `UpdateFailed`, HA's `DataUpdateCoordinator` halves the polling rate after consecutive failures (built-in `_unsub_refresh` reschedule), naturally reducing pressure. Net effect: fewer API calls under sustained throttling, not more.
+- **401/403 behavior:** *much better.* Today: poll forever, log an error every 20s, never recover. New: one call → reauth banner → user re-enters token → entry reloads → polling resumes.
+
+---
+
+### 4. Transport layer: lock + backoff + `Retry-After` + unbound-var + `close()` removal + GET-under-limit policy
+
+**File:** `custom_components/sleepme_thermostat/sleepme_api.py`
+
+This is the biggest single rewrite in Phase 1. Five bugs and one policy decision in the same file. Rewrite `SleepMeAPI` end-to-end; do not patch around the existing structure.
+
+**Policy decision (audit #5): GET-under-rate-limit.**
+
+Choose **(a) raise**, specifically a new `SleepMeRateLimited` exception that the coordinator catches and translates to `UpdateFailed`. Rationale:
+
+- The maintainer's strong preference: "do not burn calls." Option (b), queueing inside the transport, can hold a coroutine for up to 60 seconds while the framework above (climate command path with its own retry-with-verify loop) is *also* timing out and retrying. That's the worst case: stacked latency without saving any API budget.
+- The coordinator already has a rescheduling cadence (20s default, with HA's exponential reduction after failures). It is cheaper to let HA's framework decide when to retry than to invent a transport-level queue.
+- The transport never knows whether a given GET is the coordinator's poll (drop is fine, framework will retry) or a one-shot like `get_claimed_devices()` (drop is bad, user gets stuck). Raising lets the caller decide.
+- For `get_claimed_devices()` specifically (config flow), `SleepMeRateLimited` should surface as `cannot_connect` with a clear log line — the user can retry the config flow manually. That's better than silent `{}` → "no devices found" → user confused.
+
+Same policy for PATCH requests under rate limit: raise rather than wait. The climate verify-after-command loop in Phase 1 still catches `Exception` and retries; the *real* climate refactor is Phase 3.
+
+**Paste-ready `SleepMeAPI` rewrite:**
+
+```python
+"""HTTP transport for the SleepMe developer API.
+
+Responsibilities:
+- Authorize requests with bearer token.
+- Rate-limit (sliding window, concurrency-safe via instance lock).
+- Retry on 429 + 5xx with monotonically increasing backoff, honoring Retry-After.
+- Surface auth failures (401/403) and connection failures as typed exceptions.
+
+Does NOT:
+- Queue requests when rate-limited. Raises SleepMeRateLimited; caller decides.
+- Manage its own httpx client lifecycle. The client is HA's shared instance.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import deque
+from email.utils import parsedate_to_datetime
+
+import httpx
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.httpx_client import get_async_client
+
+_LOGGER = logging.getLogger(__name__)
+
+MAX_REQUESTS_PER_MINUTE = 9
+RATE_LIMIT_WINDOW = 60          # seconds
+DEFAULT_RETRIES = 3
+BACKOFF_BASE_429 = 30           # seconds
+BACKOFF_BASE_5XX = 10           # seconds
+BACKOFF_BASE_TIMEOUT = 10       # seconds
+BACKOFF_CEILING = 600           # seconds (10 min); Retry-After can exceed this -- we honor it anyway
+
+
+class SleepMeAPIError(Exception):
+    """Base for typed transport errors."""
+
+
+class SleepMeAuthError(SleepMeAPIError):
+    """401/403 from the API. Coordinator should raise ConfigEntryAuthFailed."""
+
+
+class SleepMeRateLimited(SleepMeAPIError):
+    """Local rate-limiter would have blocked the request. Caller decides retry."""
+
+
+class SleepMeConnectionError(SleepMeAPIError):
+    """Network-level failure. Coordinator should raise UpdateFailed."""
+
+
+class SleepMeAPI:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        api_url: str,
+        token: str,
+        max_requests_per_minute: int = MAX_REQUESTS_PER_MINUTE,
+    ) -> None:
+        self.api_url = api_url
+        self.token = token
+        self.client = get_async_client(hass)
+        self._request_times: deque[float] = deque(maxlen=max_requests_per_minute)
+        self._lock = asyncio.Lock()  # instance-level — fixes audit #2
+
+    # NOTE: no close() method — see audit #26. The httpx client is shared and
+    # owned by HA.
+
+    async def api_request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        params: dict | None = None,
+        data: dict | None = None,
+        input_headers: dict | None = None,
+        retries: int = DEFAULT_RETRIES,
+    ):
+        """Send one request with retry-on-transient-error.
+
+        Raises:
+            SleepMeAuthError on 401/403.
+            SleepMeRateLimited if local rate limiter would block (no queueing).
+            SleepMeConnectionError on network/timeout.
+            httpx.HTTPStatusError on non-retriable HTTP errors (4xx other than 401/403/429).
+        """
+        attempt = 1
+        while True:
+            await self._enforce_local_rate_limit(method, endpoint)
+            try:
+                return await self._perform_request(
+                    method, endpoint, params=params, data=data, input_headers=input_headers
+                )
+            except httpx.HTTPStatusError as err:
+                status = err.response.status_code
+                if status in (401, 403):
+                    raise SleepMeAuthError(f"{status} from {endpoint}") from err
+                if status == 429 and attempt <= retries:
+                    backoff = self._compute_backoff(BACKOFF_BASE_429, attempt, err.response)
+                    _LOGGER.warning(
+                        "429 on %s %s; attempt %d/%d, sleeping %.1fs",
+                        method, endpoint, attempt, retries, backoff,
+                    )
+                    await asyncio.sleep(backoff)
+                    attempt += 1
+                    continue
+                if status in (500, 502, 503, 504) and attempt <= retries:
+                    backoff = self._compute_backoff(BACKOFF_BASE_5XX, attempt, err.response)
+                    _LOGGER.warning(
+                        "HTTP %d on %s %s; attempt %d/%d, sleeping %.1fs",
+                        status, method, endpoint, attempt, retries, backoff,
+                    )
+                    await asyncio.sleep(backoff)
+                    attempt += 1
+                    continue
+                # Non-retriable / out of retries: let caller see the original exception.
+                raise
+            except httpx.TimeoutException as err:
+                if attempt > retries:
+                    raise SleepMeConnectionError(f"timeout on {endpoint}") from err
+                backoff = BACKOFF_BASE_TIMEOUT * (2 ** (attempt - 1))
+                _LOGGER.warning(
+                    "Timeout on %s %s; attempt %d/%d, sleeping %.1fs",
+                    method, endpoint, attempt, retries, backoff,
+                )
+                await asyncio.sleep(min(backoff, BACKOFF_CEILING))
+                attempt += 1
+            except httpx.RequestError as err:
+                # DNS, connection refused, etc. Not worth retrying within this call;
+                # coordinator's next poll will retry.
+                raise SleepMeConnectionError(f"request error on {endpoint}: {err}") from err
+
+    async def _enforce_local_rate_limit(self, method: str, endpoint: str) -> None:
+        """Either record the current request or raise SleepMeRateLimited.
+
+        Sliding window: if the deque is full and the oldest entry is within the
+        60s window, we are at capacity. Per the deliberate policy (audit #5),
+        we do not queue. The caller -- coordinator for GET, climate command path
+        for PATCH -- decides what to do.
+        """
+        async with self._lock:
+            now = time.monotonic()
+            # Drop entries older than the window so the deque reflects reality.
+            while self._request_times and now - self._request_times[0] >= RATE_LIMIT_WINDOW:
+                self._request_times.popleft()
+
+            if len(self._request_times) >= self._request_times.maxlen:
+                wait = RATE_LIMIT_WINDOW - (now - self._request_times[0])
+                _LOGGER.warning(
+                    "Local rate limit hit on %s %s; would need to wait %.1fs. Rejecting.",
+                    method, endpoint, wait,
+                )
+                raise SleepMeRateLimited(
+                    f"{method} {endpoint}: local rate-limiter at capacity"
+                )
+
+            self._request_times.append(now)
+
+    async def _perform_request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        params: dict | None,
+        data: dict | None,
+        input_headers: dict | None,
+    ):
+        headers = dict(input_headers or {})
+        headers["Authorization"] = f"Bearer {self.token}"
+        response = await self.client.request(
+            method,
+            f"{self.api_url}/{endpoint}",
+            headers=headers,
+            json=data,
+            params=params,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def _compute_backoff(base: int, attempt: int, response: httpx.Response) -> float:
+        """Resolve backoff seconds.
+
+        Honors the server-provided Retry-After (integer seconds or HTTP-date).
+        Falls back to base * 2**(attempt-1), capped at BACKOFF_CEILING.
+        """
+        ra = response.headers.get("Retry-After")
+        if ra:
+            try:
+                return float(int(ra))
+            except ValueError:
+                try:
+                    target = parsedate_to_datetime(ra).timestamp()
+                    return max(0.0, target - time.time())
+                except (TypeError, ValueError):
+                    _LOGGER.debug("Unparsable Retry-After: %r", ra)
+        return min(base * (2 ** (attempt - 1)), BACKOFF_CEILING)
+```
+
+**Behavioral diff summary (audit ## 2, 3, 4, 5, 26):**
+
+| # | Before | After |
+|---|---|---|
+| 2 | `async with asyncio.Lock():` — fresh lock per call, locks nothing. | `self._lock` created in `__init__`; sliding-window deque mutation is critical-section-protected. |
+| 3 | `initial_backoff * 2**(retries-1)` with `retries` decrementing 3→1: produced 120/60/30s. | `base * 2**(attempt-1)` with `attempt` incrementing 1→3: produces 30/60/120s. Plus `Retry-After` override. |
+| 4 | `initial_backoff` referenced before assignment for HTTPStatusError codes outside `{403, 429, 500, 502, 503, 504}`. | Variable replaced by explicit per-status branching. Non-matched statuses no longer reach the `await asyncio.sleep(backoff_time)` line. |
+| 5 | GET-under-rate-limit → silent `return {}`. | GET-under-rate-limit → `raise SleepMeRateLimited`. Coordinator translates to `UpdateFailed`. |
+| 26 | `close()` would close HA's shared httpx client. | Method removed. |
+
+**Caller adjustments:**
+
+- `sleepme.py:get_claimed_devices()` and `get_device_status()` currently swallow `ValueError("cannot_connect")` and `ValueError("invalid_token")` raised by the old `handle_error`. With the new typed exceptions, update `sleepme.py` to let `SleepMeAuthError` / `SleepMeConnectionError` / `SleepMeRateLimited` propagate. Coordinator catches them.
+- `config_flow.py:async_step_user` catches `ValueError("invalid_token")`. Update it to catch `SleepMeAuthError` directly. Keep the existing string-based fallback for backward compat with the one transitional release (or just delete it — Phase 1 is the right time, since `sleepme_api.py` no longer raises bare `ValueError`).
+
+**Diff shape:** `sleepme_api.py` is essentially rewritten — ~110 lines deleted, ~180 added (net +70). `sleepme.py` ~15 lines changed. `config_flow.py` ~5 lines changed. New exception classes are co-located in `sleepme_api.py`; do not introduce a separate `exceptions.py` in Phase 1.
+
+**API-budget impact:**
+- **Per-user-action delta:** 0 calls in the common case (no rate limit hit). When the local rate-limiter is at capacity, the user action now *fails fast* instead of waiting up to 60s. Phase 3 fixes the user-facing behavior of "set temperature failed because rate-limited" — Phase 1 just stops burning calls on doomed retries.
+- **Per-minute idle delta:** 0 calls in steady state. Under 429-from-server, behavior is dominated by `Retry-After`. Old code: `30 → 60 → 120` (computed as `120, 60, 30` due to inverted math) before giving up = 3 wasted calls in 210s. New code: honors `Retry-After` (server's actual recovery window) up to 3 retries = at most 3 calls during the server's recovery window. If `Retry-After` says 300s, we wait 300s instead of retrying every 30s. **This is the biggest budget win in Phase 1.**
+- **429 behavior:** strictly fewer wasted calls. Cannot be worse than today; in practice will be measurably better.
+
+---
+
+### 5. Reauth flow
+
+**File:** `custom_components/sleepme_thermostat/config_flow.py`
+
+**Trigger path:**
+1. Coordinator's `_async_update_data` catches 401/403 → raises `ConfigEntryAuthFailed`.
+2. HA framework moves the entry to `SETUP_ERROR` and dispatches `entry.async_start_reauth(hass)`.
+3. HA looks up the config flow class on the integration, calls `async_step_reauth(entry_data)`.
+4. User sees a repair-flow banner ("SleepMe Thermostat needs to re-authenticate"). Click → form.
+5. User enters new token. We validate against the API. On success: update entry data, reload, dismiss.
+
+**Paste-ready additions to `SleepMeThermostatConfigFlow`:**
+
+```python
+from homeassistant.config_entries import ConfigEntry, SOURCE_REAUTH
+
+
+class SleepMeThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    VERSION = 3
+
+    def __init__(self) -> None:
+        self.api_token: str = ""
+        self.claimed_devices: list = []
+        self._reauth_entry: ConfigEntry | None = None
+
+    # ---- existing async_step_user / async_step_select_device unchanged ----
+
+    async def async_step_reauth(self, entry_data: dict) -> FlowResult:
+        """Begin reauth — token was rejected by the API."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input=None) -> FlowResult:
+        """Prompt for a new API token and validate it."""
+        errors: dict[str, str] = {}
+        assert self._reauth_entry is not None
+
+        if user_input is not None:
+            new_token = user_input["api_token"]
+            client = SleepMeClient(self.hass, API_URL, new_token)
+            try:
+                # Cheapest possible validation: list claimed devices.
+                # We also confirm the existing device_id is still in the list,
+                # so a user pasting a different account's token can't silently
+                # break the existing entry.
+                claimed = await client.get_claimed_devices()
+                existing_device_id = self._reauth_entry.data["device_id"]
+                if not any(d.get("id") == existing_device_id for d in claimed):
+                    errors["base"] = "device_not_found_for_token"
+                else:
+                    return self.async_update_reload_and_abort(
+                        self._reauth_entry,
+                        data={**self._reauth_entry.data, "api_token": new_token},
+                        reason="reauth_successful",
+                    )
+            except SleepMeAuthError:
+                errors["base"] = "invalid_token"
+            except (SleepMeConnectionError, SleepMeRateLimited, HTTPStatusError):
+                errors["base"] = "cannot_connect"
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Unexpected error during reauth")
+                errors["base"] = "cannot_connect"
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required("api_token"): str}),
+            errors=errors,
+        )
+```
+
+**Translation file additions (`translations/en.json` and `es.json`):**
+
+```json
+{
+  "config": {
+    "step": {
+      "reauth_confirm": {
+        "title": "Re-authenticate SleepMe Dock Pro",
+        "description": "Your SleepMe API token is no longer valid. Enter a new token to reconnect.",
+        "data": { "api_token": "API Token" }
+      }
+    },
+    "error": {
+      "device_not_found_for_token": "This token does not have access to the originally configured device."
+    },
+    "abort": {
+      "reauth_successful": "Re-authentication was successful."
+    }
+  }
+}
+```
+
+(`strings.json` migration is Phase 2 — for Phase 1, edit `en.json`/`es.json` directly to match the existing pattern.)
+
+**Diff shape:** `config_flow.py` ~50 lines added, ~5 changed. Translation files ~15 lines added each.
+
+**API-budget impact per reauth event:** 1 GET (`get_claimed_devices`) per token attempt. This is unavoidable — we have to confirm the token works before persisting it.
+
+---
+
+### 6. Tests covering the above
+
+**Phase 1 test scope is deliberately narrow** — Phase 4 is the full testing phase. The rule for Phase 1 is: every behavior we fix must have at least one regression test, sized so that the next dormant period can't silently undo the work.
+
+**New tests:**
+
+1. **`tests/test_init.py::test_unload_entry`** — flip the existing `xfail` to a real assertion. No body changes needed beyond removing the `pytest.xfail(...)` line.
+
+2. **`tests/test_init.py::test_multi_entry_isolation`** — set up two `MockConfigEntry` instances with distinct `entry_id` / `device_id`; assert both reach `LOADED`; assert `hass.data[DOMAIN]` has two distinct keys; unload one and assert the other is still loaded.
+
+3. **`tests/test_coordinator.py`** (new file). Three tests:
+   - `test_auth_failed_raises_reauth`: mock `client.get_device_status` to raise `httpx.HTTPStatusError` with status 401; assert `ConfigEntryAuthFailed` propagates from `_async_update_data` and `entry.state` ends in `SETUP_ERROR`; assert reauth flow has been started (`hass.config_entries.flow.async_progress_by_handler(DOMAIN)` is non-empty with `source == "reauth"`).
+   - `test_transient_failure_raises_update_failed`: mock client to raise `httpx.TimeoutException`; assert `UpdateFailed` propagates; assert `coordinator.last_update_success is False`.
+   - `test_rate_limited_raises_update_failed`: mock client to raise `SleepMeRateLimited`; same assertions.
+
+4. **`tests/test_config_flow.py`** (new file). Three tests:
+   - `test_happy_path` (small): two-step user flow → reaches `CREATE_ENTRY`. Verifies the existing flow still works after the typed-exception changes in deliverable 4.
+   - `test_user_step_invalid_token`: `get_claimed_devices` raises `SleepMeAuthError`; assert form re-shows with `errors["base"] == "invalid_token"`.
+   - `test_reauth_flow`: set up an entry, trigger `async_start_reauth`, submit form with new token, assert entry data updated and entry reloaded.
+
+5. **`tests/test_sleepme_api.py`** (new file). Three tests, no real network:
+   - `test_backoff_progression_monotonically_increases`: mock `client.request` to return a 429 response with no `Retry-After`; assert `asyncio.sleep` is called with 30, then 60, then 120 (use `patch("asyncio.sleep", AsyncMock())` and inspect call_args_list).
+   - `test_honors_retry_after_integer`: mock 429 with `Retry-After: 7`; assert next `asyncio.sleep` is called with 7.
+   - `test_get_under_rate_limit_raises`: fill the deque manually (`api._request_times.extend([time.monotonic()] * 9)`); call `api_request("GET", ...)`; assert raises `SleepMeRateLimited`.
+
+**`tests/conftest.py` cleanup:** delete the `expected_lingering_timers` fixture entirely. After `async_unload_entry` lands, the coordinator's timer is canceled on unload, so the lingering-timer guard is correct as-is. If a test still trips it, that's a real bug to fix, not to suppress.
+
+**Diff shape:**
+- `tests/conftest.py`: ~10 lines deleted (the fixture).
+- `tests/test_init.py`: ~3 lines changed (xfail removal), ~30 lines added (`test_multi_entry_isolation`).
+- `tests/test_coordinator.py`: new, ~80 lines.
+- `tests/test_config_flow.py`: new, ~120 lines.
+- `tests/test_sleepme_api.py`: new, ~100 lines.
+
+Approximate total: ~350 new test LOC. This is right-sized for Phase 1 — covers every Phase 1 behavior change, defers the broader sensor/climate coverage to Phase 4.
+
+---
+
+### 7. Lift Phase 0 workarounds
+
+Two small but important loose ends:
+
+1. **`tests/conftest.py` — delete the `expected_lingering_timers` fixture.** Covered in deliverable 6. Doc comment in the fixture today says "Phase 1 lands the unload and this fixture should be removed."
+2. **`tests/test_init.py::test_unload_entry` — flip the `xfail` to a real pass.** Covered in deliverable 6.
+
+3. **Pre-commit `files: ^tests/` scoping — defer flipping to Phase 2.** Justification: Phase 1 produces a mechanically dense diff inside `custom_components/` (transport rewrite + storage-shape change + reauth). Layering a "ruff/black format everything" reformat-only commit on top of that PR makes the diff hard to review and risks losing review attention to formatting rather than correctness. The right move: land Phase 1 as a behavior-only PR; Phase 2 opens with a single format-only commit (`ruff --fix custom_components/`, `black custom_components/`) followed by `files:` removal.
+
+## API-call-budget analysis
+
+| Scenario | Today | After Phase 1 | Delta |
+|---|---|---|---|
+| Idle, no errors, 1 device, 20s poll | 3 GET/min | 3 GET/min | 0 |
+| Idle, no errors, 2 devices, 20s poll | 6 GET/min (but second device clobbered hass.data, second poll may also fail invisibly) | 6 GET/min, both polls real | now correctly accounts for the second device; not a regression |
+| User drags slider once | 1 PATCH + (up to 3 GET in verify loop) | 1 PATCH + (up to 3 GET in verify loop) — *Phase 3 fixes this* | 0 in Phase 1 |
+| Sustained 429 from server, no `Retry-After` | 30 + 60 + 120 = ~3 retries over 210s, then `{}` returned (silent fail) → coordinator retries 20s later | 30 + 60 + 120 = same 3 retries, then `UpdateFailed` → HA framework backs off polling (e.g. doubles interval) | Fewer wasted calls; framework handles long-tail backoff. |
+| Sustained 429 from server, with `Retry-After: 300` | Ignored; 3 retries at 30/60/120s = 3 calls during the server's 300s recovery window — likely all 429 | Honored: first retry waits 300s; only 1 wasted call instead of 3 | **-2 calls per throttle event.** |
+| Invalid token | Coordinator silently returns stale data forever; user sees no error; integration polls every 20s = 3 GET/min indefinitely | One GET → `ConfigEntryAuthFailed` → reauth banner → polling halted until user resolves | **Down to 0 calls/min after first failure.** |
+| Reauth flow itself | N/A (no flow exists) | 1 GET per submitted token attempt | +1–N per reauth event (rare) |
+
+**Net Phase 1 budget impact:**
+- Steady state: 0 delta.
+- Under 429 with `Retry-After`: strictly fewer calls.
+- Under 401/403: dramatic reduction (poll stops until reauth).
+- Per user action: 0 delta. The big climate-side win is Phase 3.
+
+## Cross-platform read-site changes
+
+Every file that reads `hass.data[DOMAIN]` needs updating. Full list:
+
+| File | Line(s) | Current read | New read |
+|---|---|---|---|
+| `__init__.py` | 17, 46, 49, 53 | Sets `hass.data[DOMAIN]["sleepme_controller"]`, `hass.data[DOMAIN][f"{device_id}_update_manager"]`, `hass.data[DOMAIN]["device_info"]` | Sets `hass.data[DOMAIN][entry.entry_id] = {"client": ..., "coordinator": ..., "device_info": ...}` |
+| `climate.py` | 29 | `hass.data[DOMAIN][f"{device_id}_update_manager"]` | `hass.data[DOMAIN][entry.entry_id]["coordinator"]` |
+| `climate.py` | 34 | `hass.data[DOMAIN][device_id] = thermostat` | **delete** |
+| `binary_sensor.py` | 13 | `hass.data[DOMAIN][f"{device_id}_update_manager"]` | `hass.data[DOMAIN][entry.entry_id]["coordinator"]` |
+| `binary_sensor.py` | 17 | `hass.data[DOMAIN].get(device_id)` (the thermostat handle) | **delete** — read `device_info` dict from `hass.data[DOMAIN][entry.entry_id]["device_info"]` instead |
+| `sensor.py` | 13 | same as binary_sensor.py:13 | same |
+| `sensor.py` | 17 | same as binary_sensor.py:17 | same |
+
+`binary_sensor.py` and `sensor.py` keep the same constructor signatures (`coordinator, thermostat, device_id, name`) for Phase 1, but `thermostat` becomes "a small `_device_info(...)` dict built locally" rather than "the climate entity." Phase 2 does the full constructor-signature cleanup (audit #10).
+
+## Validation steps against live device
+
+Maintainer's two devices (`Dock Pro Ramon`, `Dock Pro Chiva`) are currently `disabled_by: user`. The validation matrix below assumes both are re-enabled in sequence.
+
+**Phase 1 validation checklist (executed by maintainer, against `100.88.154.98`):**
+
+1. `make deploy-restart HA_HOST=100.88.154.98` — confirm `ha core restart` completes; tail `home-assistant.log` for `Entry <id> set up for device <device_id>` and absence of `Traceback`.
+2. **Token-leak check.** Set log level for `custom_components.sleepme_thermostat` to `debug`. Reload entry. `grep -i "api token\|bearer" /config/home-assistant.log`. Expected: zero matches.
+3. **Multi-device check.** Re-enable both `Dock Pro Ramon` and `Dock Pro Chiva`. Confirm both appear in `/config/.storage/core.config_entries` with state `loaded`. Confirm both have working `climate.*` entities reading distinct temperatures (i.e. one entry isn't shadowing the other — that's the multi-device clobber regression).
+4. **Unload check.** Settings → Devices & Services → SleepMe → ... → "Delete" on `Dock Pro Chiva`; re-add via the existing flow. Confirm no `ha core restart` is needed. Confirm `Dock Pro Ramon` stays loaded throughout. This is the live-host version of `test_unload_entry`.
+5. **Reauth check.** In the HA UI, edit the `Dock Pro Ramon` entry (or use `homeassistant.dev_tools` to corrupt `entry.data["api_token"]` directly — easier than rotating a real token). Wait one coordinator cycle (≤20s). Expect:
+   - A repair-flow notification appears.
+   - Clicking it opens the "Re-authenticate SleepMe Dock Pro" form (English text matches the new translation key).
+   - Entering the *original* (valid) token submits → form closes → entry reloads → entities resume.
+6. **Rate-limit dry run.** This is the hardest one to test in production without burning real API budget. Plan: rather than triggering real 429s, write a temporary test fixture that monkey-patches `SleepMeAPI.client.request` to return a `httpx.Response(429, headers={"Retry-After": "5"})` for the next N calls. Run in the test suite, not against live API. If a maintainer wants live confirmation, the cheapest path is to set `MAX_REQUESTS_PER_MINUTE = 2` in `const.py` as a temporary override and watch the local rate limiter kick in — confirms `SleepMeRateLimited` → `UpdateFailed` path end-to-end.
+7. **Token-leak in logs (post-reauth).** After step 5, re-grep the log for the token value. Confirm the new (or pasted-back) token does not appear.
+
+**Order of re-enabling devices:**
+- Step 1: enable `Dock Pro Ramon` first; complete checks 1–5 against the single device.
+- Step 2: enable `Dock Pro Chiva`; verify check 3 (multi-device isolation).
+- Step 3: with both running, repeat check 5 (reauth) on `Dock Pro Chiva` to confirm reauth works per-entry, not globally.
+
+## Acceptance / exit criteria
+
+Every box must be checked before Phase 1 is declared done.
+
+- [ ] `ruff check tests` and `black --check tests` pass.
+- [ ] `mypy custom_components/sleepme_thermostat` passes (advisory mode unchanged from Phase 0).
+- [ ] `pytest` passes including new tests in `test_coordinator.py`, `test_config_flow.py`, `test_sleepme_api.py`, and `test_init.py::test_multi_entry_isolation`.
+- [ ] `tests/test_init.py::test_unload_entry` is no longer marked `xfail` and passes as a normal test.
+- [ ] `tests/conftest.py` no longer defines `expected_lingering_timers`.
+- [ ] `grep -i "api token\|bearer" custom_components/sleepme_thermostat/` returns no `_LOGGER.debug(...)` lines that interpolate the token.
+- [ ] `SleepMeAPI.close()` is removed from `sleepme_api.py`.
+- [ ] `SleepMeAPI._lock` is created in `__init__`, not inside `api_request`.
+- [ ] Backoff progression test asserts 30/60/120 (monotonically increasing).
+- [ ] `Retry-After` test asserts honored.
+- [ ] `update_manager._async_update_data` raises `ConfigEntryAuthFailed` on 401/403 and `UpdateFailed` otherwise; no `try/except: return last_status` fallback remains.
+- [ ] `__init__.py` defines `async_unload_entry`; `hass.data[DOMAIN]` is keyed by `entry.entry_id`.
+- [ ] `climate.py`, `binary_sensor.py`, `sensor.py` read from `hass.data[DOMAIN][entry.entry_id]["coordinator"]`.
+- [ ] `config_flow.py` has `async_step_reauth` + `async_step_reauth_confirm`; `en.json` and `es.json` updated.
+- [ ] Maintainer ran the live-device validation checklist above (token redaction, multi-device, unload, reauth) — all 7 steps green.
+- [ ] `docs/ROADMAP.md` Phase 1 table flipped ⬜ → ✅.
+- [ ] HACS validate workflow, hassfest, CodeQL, and the Phase 0 `Test` workflow all green on the PR.
+
+## Risks and open questions
+
+1. **Coordinator's stale-data semantics.** Removing `_last_valid_status` means that on a single failed poll, `coordinator.data` is briefly `None` until the next successful one. `CoordinatorEntity` handles this — entities go `available=False` and re-render when data arrives. Phase 2 may want to revisit "should we hold last-good for X seconds before going unavailable?" but Phase 1 should not paper over the framework's behavior.
+
+2. **`SleepMeAPI.api_request` retry loop now blocks inside the lock.** It doesn't — the lock is held only inside `_enforce_local_rate_limit`. *Double-check during implementation* that the `asyncio.sleep` calls for 429/timeout retries are outside the `async with self._lock` block. If a retry sleeps while holding the lock, every other in-flight request to the SleepMe API stalls.
+
+3. **`Retry-After` precedence over local rate limiter.** If the server says "wait 300s" via `Retry-After`, we sleep 300s inside `api_request`. During that sleep, the local deque is *not* cleared — so a concurrent caller could hit the local rate limiter and raise `SleepMeRateLimited`. This is actually fine: the server is asking us to stop, so we should *also* be locally throttling. Document this in the transport docstring.
+
+4. **`get_claimed_devices()` retries=1.** Today's config-flow call uses `retries=1`. With typed exceptions, `SleepMeAuthError` short-circuits — so retries only matter for 429/5xx during config flow. Decision: keep config-flow's retries=1; user can re-click the form.
+
+5. **HA Core version of `ConfigEntryAuthFailed`.** Available since HA 2022.4. The pin (HA 2026.5.x) is well past that. No risk.
+
+6. **Backwards-compatible config entry version.** `VERSION = 3` today. Phase 1 does not change `entry.data` schema. No `async_migrate_entry` needed. Phase 5 may remove `api_url` and `name` (audit P2 list), at which point version bumps.
+
+7. **Two devices, shared rate limiter.** Each `SleepMeAPI` instance has its own `_request_times` deque. With two devices, we have two independent rate limiters → could collectively hit the per-account server-side rate limit. Out of scope for Phase 1; Phase 4/5 could share the deque across instances if observed in practice.
+
+## Out of scope (explicit)
+
+| Item | Phase |
+|---|---|
+| `climate.py` verify-after-command retry loop removal | 3 |
+| Optimistic state + `async_request_refresh` after PATCH | 3 |
+| `ServiceValidationError` on out-of-range temperatures | 3 |
+| `min_temp` 12.5 → 12.78 | 3 |
+| Sensor `state` → `native_value` migration | 2 |
+| `_attr_has_entity_name = True` adoption | 2 |
+| Options flow (poll interval) | 2 |
+| `strings.json` source-of-truth migration | 2 |
+| `async_step_import` removal | 2 |
+| `hass.components.persistent_notification.create` replacement | 2 (already deleted in Phase 1 via the cross-platform handle removal, but the broader pattern audit stays Phase 2) |
+| `diagnostics.py` platform | 5 |
+| `round_half_up` deduplication | 3 |
+| Flipping pre-commit `files: ^tests/` to full repo | 2 |
+| Coverage gate at ≥ 75% | 4 |
+| Multi-version HA test matrix | 4 |
+| Logging f-string → lazy `%s` everywhere | 2 (Phase 1 only changes lines it's already touching) |
+| Sharing rate-limiter deque across `SleepMeAPI` instances | 4/5 if needed |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,16 +16,6 @@ def auto_enable_custom_integrations(enable_custom_integrations):
     yield
 
 
-@pytest.fixture(autouse=True)
-def expected_lingering_timers() -> bool:
-    """Phase 0: tolerate lingering timers because the integration has no
-    async_unload_entry yet (audit #7). The DataUpdateCoordinator's polling
-    timer survives teardown. Phase 1 lands the unload and this fixture
-    should be removed so the lingering-timer check protects future regressions.
-    """
-    return True
-
-
 @pytest.fixture
 def mock_sleepme_client() -> Generator[AsyncMock]:
     """Mock SleepMeClient so no real network calls happen.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,216 @@
+"""Config flow tests: happy path, invalid token, reauth."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from custom_components.sleepme_thermostat.const import API_URL, DOMAIN
+from custom_components.sleepme_thermostat.sleepme_api import (
+    SleepMeAuthError,
+    SleepMeConnectionError,
+)
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from tests.const import MOCK_API_TOKEN, MOCK_DEVICE_ID, MOCK_NAME
+
+
+@pytest.fixture
+def mock_flow_client():
+    """Patch the SleepMeClient used by config_flow."""
+    with patch(
+        "custom_components.sleepme_thermostat.config_flow.SleepMeClient",
+        autospec=True,
+    ) as mock_cls:
+        instance = mock_cls.return_value
+        instance.get_claimed_devices = AsyncMock(
+            return_value=[{"id": MOCK_DEVICE_ID, "name": MOCK_NAME}]
+        )
+        instance.get_device_status = AsyncMock(
+            return_value={
+                "about": {
+                    "firmware_version": "1.0",
+                    "mac_address": "aa:bb:cc:dd:ee:ff",
+                    "model": "Dock Pro",
+                    "serial_number": "SN-1",
+                }
+            }
+        )
+        yield instance
+
+
+async def test_happy_path(hass: HomeAssistant, mock_flow_client: AsyncMock) -> None:
+    """User flow reaches CREATE_ENTRY with expected data."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"api_token": MOCK_API_TOKEN}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "select_device"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"device_id": MOCK_DEVICE_ID}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"Dock Pro {MOCK_NAME}"
+    assert result["data"]["api_token"] == MOCK_API_TOKEN
+    assert result["data"]["device_id"] == MOCK_DEVICE_ID
+    assert result["data"]["model"] == "Dock Pro"
+
+
+async def test_user_step_invalid_token(
+    hass: HomeAssistant, mock_flow_client: AsyncMock
+) -> None:
+    """SleepMeAuthError on the user step surfaces as errors['base']='invalid_token'."""
+    mock_flow_client.get_claimed_devices.side_effect = SleepMeAuthError("403")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"api_token": "bad-token"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "invalid_token"}
+
+
+async def test_user_step_cannot_connect(
+    hass: HomeAssistant, mock_flow_client: AsyncMock
+) -> None:
+    """Connection failure surfaces as errors['base']='cannot_connect'."""
+    mock_flow_client.get_claimed_devices.side_effect = SleepMeConnectionError("dns")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"api_token": MOCK_API_TOKEN}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_reauth_flow(hass: HomeAssistant, mock_flow_client: AsyncMock) -> None:
+    """Reauth: existing entry, new token validated, entry updated and aborted as success."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="entry_reauth",
+        version=3,
+        unique_id=MOCK_DEVICE_ID,
+        title=f"Dock Pro {MOCK_NAME}",
+        data={
+            "api_url": API_URL,
+            "api_token": "old-token",
+            "device_id": MOCK_DEVICE_ID,
+            "name": MOCK_NAME,
+            "firmware_version": "1.0",
+            "mac_address": "aa:bb:cc:dd:ee:ff",
+            "model": "Dock Pro",
+            "serial_number": "SN-1",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    # Start the reauth flow as if HA's framework triggered it.
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    # Submit a new token; mock_flow_client.get_claimed_devices returns the same device_id.
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"api_token": "new-token"}
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data["api_token"] == "new-token"
+
+
+async def test_reauth_token_for_other_account(
+    hass: HomeAssistant, mock_flow_client: AsyncMock
+) -> None:
+    """Token that doesn't have access to the configured device_id is rejected."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="entry_other_acct",
+        version=3,
+        unique_id=MOCK_DEVICE_ID,
+        title=f"Dock Pro {MOCK_NAME}",
+        data={
+            "api_url": API_URL,
+            "api_token": "old-token",
+            "device_id": MOCK_DEVICE_ID,
+            "name": MOCK_NAME,
+            "firmware_version": "1.0",
+            "mac_address": "aa:bb:cc:dd:ee:ff",
+            "model": "Dock Pro",
+            "serial_number": "SN-1",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    # New token returns a *different* device list — doesn't include our device_id.
+    mock_flow_client.get_claimed_devices.return_value = [
+        {"id": "other-device", "name": "Other"}
+    ]
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"api_token": "different-account-token"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "device_not_found_for_token"}
+    assert entry.data["api_token"] == "old-token"  # unchanged
+
+
+async def test_reauth_invalid_token(
+    hass: HomeAssistant, mock_flow_client: AsyncMock
+) -> None:
+    """SleepMeAuthError on the reauth step surfaces as invalid_token."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="entry_invalid",
+        version=3,
+        unique_id=MOCK_DEVICE_ID,
+        title=f"Dock Pro {MOCK_NAME}",
+        data={
+            "api_url": API_URL,
+            "api_token": "old-token",
+            "device_id": MOCK_DEVICE_ID,
+            "name": MOCK_NAME,
+            "firmware_version": "1.0",
+            "mac_address": "aa:bb:cc:dd:ee:ff",
+            "model": "Dock Pro",
+            "serial_number": "SN-1",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    mock_flow_client.get_claimed_devices.side_effect = SleepMeAuthError("403")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"api_token": "still-bad"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_token"}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,135 @@
+"""Coordinator error-translation tests."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from custom_components.sleepme_thermostat.const import API_URL, DOMAIN
+from custom_components.sleepme_thermostat.sleepme_api import (
+    SleepMeAuthError,
+    SleepMeConnectionError,
+    SleepMeRateLimited,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from tests.const import MOCK_API_TOKEN, MOCK_DEVICE_ID, MOCK_NAME
+
+
+def _entry() -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="entry_coord_test",
+        version=3,
+        unique_id=MOCK_DEVICE_ID,
+        title=f"Dock Pro {MOCK_NAME}",
+        data={
+            "api_url": API_URL,
+            "api_token": MOCK_API_TOKEN,
+            "device_id": MOCK_DEVICE_ID,
+            "name": MOCK_NAME,
+            "firmware_version": "0.0.0-test",
+            "mac_address": "aa:bb:cc:dd:ee:ff",
+            "model": "Dock Pro",
+            "serial_number": "TEST-SERIAL",
+        },
+    )
+
+
+@pytest.fixture
+def mock_failing_client():
+    """Patch SleepMeClient at both import sites and return the get_device_status mock."""
+    with (
+        patch(
+            "custom_components.sleepme_thermostat.SleepMeClient", autospec=True
+        ) as mock_init_cls,
+        patch(
+            "custom_components.sleepme_thermostat.update_manager.SleepMeClient",
+            autospec=True,
+        ) as mock_um_cls,
+    ):
+        get_status = AsyncMock()
+        for cls in (mock_init_cls, mock_um_cls):
+            cls.return_value.get_device_status = get_status
+            cls.return_value.get_claimed_devices = AsyncMock(return_value=[])
+        yield get_status
+
+
+async def test_auth_failed_triggers_reauth(
+    hass: HomeAssistant, mock_failing_client: AsyncMock
+) -> None:
+    """SleepMeAuthError from the client surfaces as SETUP_ERROR and starts a reauth flow."""
+    mock_failing_client.side_effect = SleepMeAuthError("401 from test")
+
+    entry = _entry()
+    entry.add_to_hass(hass)
+
+    # First refresh raises ConfigEntryAuthFailed -> setup fails -> reauth starts.
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert any(f["context"].get("source") == "reauth" for f in flows)
+
+
+async def test_transient_failure_raises_update_failed(
+    hass: HomeAssistant, mock_failing_client: AsyncMock
+) -> None:
+    """A timeout from the client maps to UpdateFailed; entry doesn't load."""
+    mock_failing_client.side_effect = SleepMeConnectionError("timeout")
+
+    entry = _entry()
+    entry.add_to_hass(hass)
+
+    # async_config_entry_first_refresh raises ConfigEntryNotReady on UpdateFailed.
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_rate_limited_raises_update_failed(
+    hass: HomeAssistant, mock_failing_client: AsyncMock
+) -> None:
+    """SleepMeRateLimited from the client maps to UpdateFailed."""
+    mock_failing_client.side_effect = SleepMeRateLimited("at capacity")
+
+    entry = _entry()
+    entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_http_status_error_maps_to_update_failed(
+    hass: HomeAssistant, mock_failing_client: AsyncMock
+) -> None:
+    """Unhandled HTTPStatusError (e.g. 500 after retries) maps to UpdateFailed."""
+    response = httpx.Response(500, request=httpx.Request("GET", "https://x/y"))
+    mock_failing_client.side_effect = httpx.HTTPStatusError(
+        "500", request=response.request, response=response
+    )
+
+    entry = _entry()
+    entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_update_failed_is_subclass_of_update_failed():
+    """Sanity: the coordinator import surface is what tests expect."""
+    from custom_components.sleepme_thermostat.update_manager import (
+        SleepMeUpdateManager,  # noqa: F401
+    )
+
+    assert UpdateFailed is UpdateFailed  # sentinel — just ensures import worked

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,29 +1,35 @@
-"""Smoke test: integration sets up and unloads cleanly with a mocked API client."""
+"""Setup/unload/multi-entry smoke tests."""
 
 from __future__ import annotations
 
 from unittest.mock import AsyncMock
 
-import pytest
 from custom_components.sleepme_thermostat.const import API_URL, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from tests.const import MOCK_API_TOKEN, MOCK_DEVICE_ID, MOCK_NAME
 
 
-def _make_entry() -> MockConfigEntry:
+def _make_entry(
+    *,
+    entry_id: str = "entry_main",
+    device_id: str = MOCK_DEVICE_ID,
+    title_suffix: str = MOCK_NAME,
+) -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
+        entry_id=entry_id,
         version=3,
-        unique_id=MOCK_DEVICE_ID,
-        title=f"Dock Pro {MOCK_NAME}",
+        unique_id=device_id,
+        title=f"Dock Pro {title_suffix}",
         data={
             "api_url": API_URL,
             "api_token": MOCK_API_TOKEN,
-            "device_id": MOCK_DEVICE_ID,
-            "name": MOCK_NAME,
+            "device_id": device_id,
+            "name": title_suffix,
             "firmware_version": "0.0.0-test",
             "mac_address": "aa:bb:cc:dd:ee:ff",
             "model": "Dock Pro",
@@ -43,22 +49,57 @@ async def test_setup_entry_loads(
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.LOADED
+    assert entry.entry_id in hass.data[DOMAIN]
+    assert "coordinator" in hass.data[DOMAIN][entry.entry_id]
 
 
 async def test_unload_entry(
     hass: HomeAssistant, mock_sleepme_client: AsyncMock
 ) -> None:
-    """Entry can be unloaded.
-
-    Phase 0 placeholder: the integration has no async_unload_entry yet (audit #7).
-    Marked xfail so CI is green; Phase 1 lands the implementation and flips this
-    to a pass, giving us a built-in regression check.
-    """
+    """Entry unloads cleanly; data is cleared; no lingering timers."""
     entry = _make_entry()
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    pytest.xfail("async_unload_entry not implemented yet — Phase 1 deliverable")
     assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
     assert entry.state is ConfigEntryState.NOT_LOADED
+    assert entry.entry_id not in hass.data[DOMAIN]
+
+
+async def test_multi_entry_isolation(
+    hass: HomeAssistant, mock_sleepme_client: AsyncMock
+) -> None:
+    """Two entries co-exist with distinct hass.data keys; unloading one leaves the other loaded."""
+    entry_a = _make_entry(
+        entry_id="entry_a", device_id="device_a", title_suffix="Ramon"
+    )
+    entry_b = _make_entry(
+        entry_id="entry_b", device_id="device_b", title_suffix="Chiva"
+    )
+    entry_a.add_to_hass(hass)
+    entry_b.add_to_hass(hass)
+
+    # Setting up the component drives setup of all registered entries.
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    assert entry_a.state is ConfigEntryState.LOADED
+    assert entry_b.state is ConfigEntryState.LOADED
+    assert "entry_a" in hass.data[DOMAIN]
+    assert "entry_b" in hass.data[DOMAIN]
+    # Distinct coordinator instances per entry.
+    assert (
+        hass.data[DOMAIN]["entry_a"]["coordinator"]
+        is not hass.data[DOMAIN]["entry_b"]["coordinator"]
+    )
+
+    # Unload one; the other survives.
+    assert await hass.config_entries.async_unload(entry_a.entry_id)
+    await hass.async_block_till_done()
+    assert entry_a.state is ConfigEntryState.NOT_LOADED
+    assert entry_b.state is ConfigEntryState.LOADED
+    assert "entry_a" not in hass.data[DOMAIN]
+    assert "entry_b" in hass.data[DOMAIN]

--- a/tests/test_sleepme_api.py
+++ b/tests/test_sleepme_api.py
@@ -1,0 +1,147 @@
+"""Transport-layer tests: backoff, Retry-After, rate-limit-raises."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from custom_components.sleepme_thermostat.sleepme_api import (
+    BACKOFF_BASE_429,
+    MAX_REQUESTS_PER_MINUTE,
+    SleepMeAPI,
+    SleepMeAuthError,
+    SleepMeRateLimited,
+)
+from homeassistant.core import HomeAssistant
+
+
+@pytest.fixture
+def api(hass: HomeAssistant) -> SleepMeAPI:
+    """Return a SleepMeAPI instance with a mocked httpx client."""
+    inst = SleepMeAPI(hass, "https://api.test/v1", "tok")
+    inst.client = MagicMock()
+    inst.client.request = AsyncMock()
+    return inst
+
+
+def _http_response(status: int, headers: dict | None = None) -> httpx.Response:
+    return httpx.Response(
+        status,
+        headers=headers or {},
+        request=httpx.Request("GET", "https://api.test/v1/devices"),
+    )
+
+
+async def test_backoff_progression_monotonically_increases(
+    api: SleepMeAPI,
+) -> None:
+    """429 with no Retry-After: backoff is 30, 60, 120 across three attempts."""
+    responses = [
+        _http_response(429),
+        _http_response(429),
+        _http_response(429),
+        _http_response(200),
+    ]
+    api.client.request.side_effect = [
+        (
+            httpx.HTTPStatusError("429", request=r.request, response=r)
+            if r.status_code == 429
+            else r
+        )
+        for r in responses
+    ]
+    # Last response needs raise_for_status to be a no-op and json() to return something.
+    # Easier path: short-circuit via mock the last call to return a real 200.
+    final_ok = MagicMock()
+    final_ok.raise_for_status = MagicMock()
+    final_ok.json = MagicMock(return_value={"ok": True})
+    api.client.request.side_effect = [
+        httpx.HTTPStatusError(
+            "429", request=responses[0].request, response=responses[0]
+        ),
+        httpx.HTTPStatusError(
+            "429", request=responses[1].request, response=responses[1]
+        ),
+        httpx.HTTPStatusError(
+            "429", request=responses[2].request, response=responses[2]
+        ),
+        final_ok,
+    ]
+
+    with patch(
+        "custom_components.sleepme_thermostat.sleepme_api.asyncio.sleep",
+        new_callable=AsyncMock,
+    ) as mock_sleep:
+        result = await api.api_request("GET", "devices", retries=3)
+
+    assert result == {"ok": True}
+    waited = [c.args[0] for c in mock_sleep.call_args_list]
+    assert waited == [
+        BACKOFF_BASE_429 * 1,  # 30
+        BACKOFF_BASE_429 * 2,  # 60
+        BACKOFF_BASE_429 * 4,  # 120
+    ]
+
+
+async def test_honors_retry_after_integer(api: SleepMeAPI) -> None:
+    """Retry-After: 7 overrides the computed backoff."""
+    final_ok = MagicMock()
+    final_ok.raise_for_status = MagicMock()
+    final_ok.json = MagicMock(return_value={"ok": True})
+    resp_429 = _http_response(429, headers={"Retry-After": "7"})
+    api.client.request.side_effect = [
+        httpx.HTTPStatusError("429", request=resp_429.request, response=resp_429),
+        final_ok,
+    ]
+
+    with patch(
+        "custom_components.sleepme_thermostat.sleepme_api.asyncio.sleep",
+        new_callable=AsyncMock,
+    ) as mock_sleep:
+        await api.api_request("GET", "devices", retries=3)
+
+    assert mock_sleep.await_args_list[0].args[0] == 7.0
+
+
+async def test_get_under_rate_limit_raises(api: SleepMeAPI) -> None:
+    """Filling the deque manually triggers SleepMeRateLimited on next call."""
+    now = time.monotonic()
+    for _ in range(MAX_REQUESTS_PER_MINUTE):
+        api._request_times.append(now)
+
+    with pytest.raises(SleepMeRateLimited):
+        await api.api_request("GET", "devices", retries=0)
+
+
+async def test_401_raises_auth_error_immediately(api: SleepMeAPI) -> None:
+    """401 is non-retriable; no sleeps; SleepMeAuthError raised."""
+    resp = _http_response(401)
+    api.client.request.side_effect = httpx.HTTPStatusError(
+        "401", request=resp.request, response=resp
+    )
+
+    with patch(
+        "custom_components.sleepme_thermostat.sleepme_api.asyncio.sleep",
+        new_callable=AsyncMock,
+    ) as mock_sleep:
+        with pytest.raises(SleepMeAuthError):
+            await api.api_request("GET", "devices", retries=3)
+
+    assert mock_sleep.await_count == 0
+
+
+async def test_compute_backoff_falls_back_when_no_retry_after() -> None:
+    """Static computation: base * 2**(attempt-1)."""
+    resp = _http_response(429)
+    assert SleepMeAPI._compute_backoff(30, 1, resp) == 30
+    assert SleepMeAPI._compute_backoff(30, 2, resp) == 60
+    assert SleepMeAPI._compute_backoff(30, 3, resp) == 120
+
+
+async def test_compute_backoff_caps_at_ceiling() -> None:
+    """Backoff cannot exceed BACKOFF_CEILING without a Retry-After."""
+    resp = _http_response(429)
+    # 30 * 2**10 = 30720, which should clamp to BACKOFF_CEILING (600).
+    assert SleepMeAPI._compute_backoff(30, 11, resp) == 600


### PR DESCRIPTION
## Summary

Closes audit P0 findings #1–#9 and #26. **Validated end-to-end against the live Dock Pro host:** the previously-swallowed coordinator error turned out to be a real auth failure (invalid/revoked token); reauth flow recovered both `Dock Pro Ramon` and `Dock Pro Chiva` entries without an HA restart.

- **Transport (`sleepme_api.py`)** — rewritten. Instance-level `asyncio.Lock` (was per-call, locked nothing), monotonically increasing backoff with `Retry-After` honoring, typed exceptions (`SleepMeAuthError` / `SleepMeRateLimited` / `SleepMeConnectionError`), `close()` removed (it would have closed HA's shared httpx client).
- **Coordinator (`update_manager.py`)** — raises `UpdateFailed` on transient errors, `ConfigEntryAuthFailed` on 401/403; `_last_valid_status` silent fallback dropped.
- **Setup/unload (`__init__.py`)** — `async_unload_entry` implemented; `hass.data` keyed by `entry.entry_id` (fixes multi-device clobber); token and other secret DEBUG logs removed; `ConfigEntryNotReady` on missing entry data.
- **Reauth (`config_flow.py` + translations)** — `async_step_reauth` + `async_step_reauth_confirm`; cross-account guard (rejects tokens that don't have access to the configured device_id); `es.json` structural fix (abort was outside config).
- **Platforms (`climate.py`, `binary_sensor.py`, `sensor.py`)** — new entry_id-keyed read sites; cross-platform thermostat handle replaced with local `_device_info()`; deprecated `persistent_notification.create` removed; sensors migrated to `native_value`.

## API budget delta

| Scenario | Delta |
|---|---|
| Idle steady state | 0 |
| 429 with Retry-After | strictly fewer wasted calls (server window honored) |
| 401/403 (invalid token) | drops to 0 — poll stops until reauth completes |

Climate verify-after-command loop stays as-is (Phase 3 owns that win).

## Tests

20 new/updated tests pass locally:

- `tests/test_init.py` — setup, unload, **multi_entry_isolation** (Phase 0's `xfail` regression trap flipped to a real pass)
- `tests/test_coordinator.py` — auth → reauth, transient/rate-limit/HTTP error → SETUP_RETRY
- `tests/test_config_flow.py` — happy path, invalid token, cannot_connect, reauth happy/wrong-account/invalid-token
- `tests/test_sleepme_api.py` — monotonic backoff (30/60/120), Retry-After, rate-limit-raises, 401 immediate, ceiling cap

Phase 0 workarounds lifted: `expected_lingering_timers` fixture removed; lingering-timer guard now protects future regressions.

## Test plan

- [x] `pre-commit run --all-files` clean locally
- [x] `pytest` — 20 passed locally
- [x] Deployed via `make deploy-restart` to live HA host
- [x] Token redacted from DEBUG logs (verified)
- [x] Multi-device: both entries hit auth-fail / reauth independently — no clobbering
- [x] Reauth UI flow accepts new token, entries reload without HA restart
- [x] No `last valid status` warnings remain after reauth completes
- [ ] CI workflows green on this PR (Test, Validate HACS, CodeQL)

## Out of scope (Phase 2+)

- `climate.py` verify-after-command retry loop removal — Phase 3 (the big rate-limit user-action win)
- Options flow (poll interval) — Phase 2
- `_attr_has_entity_name = True` adoption — Phase 2
- `strings.json` migration — Phase 2

See `docs/phase-1-p0-fixes.md` for the detailed plan that drove this PR, and `docs/ROADMAP.md` for the overall trajectory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reauthentication flow to update API tokens without full reconfiguration
  * Multi-device support for simultaneous SleepMe thermostat operations

* **Bug Fixes**
  * Improved authentication error detection and user-facing messaging
  * Corrected rate-limit handling and retry backoff behavior
  * Fixed integration unload/reload lifecycle

* **Improvements**
  * Reduced logging of sensitive authentication data
  * Enhanced setup reliability and error handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rsampayo/sleepme_thermostat/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->