### PR TITLE
Phase 5: Polish & v4.0.0 release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,117 @@
 # SleepMe Dock Pro Integration
 
-[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-Custom%20Component-%2341BDF5.svg?style=for-the-badge)](https://www.home-assistant.io/)
-[![hacs][hacsbadge]](https://github.com/hacs/default)
+[![HACS Custom Repository](https://img.shields.io/badge/HACS-Custom_Repository-41BDF5.svg)](https://github.com/hacs/default)
+[![Quality Scale](https://img.shields.io/badge/Quality_Scale-silver-c0c0c0.svg)](https://www.home-assistant.io/docs/quality_scale/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Test](https://github.com/rsampayo/sleepme_thermostat/actions/workflows/test.yml/badge.svg)](https://github.com/rsampayo/sleepme_thermostat/actions/workflows/test.yml)
+[![Validate HACS](https://github.com/rsampayo/sleepme_thermostat/actions/workflows/validate.yml/badge.svg)](https://github.com/rsampayo/sleepme_thermostat/actions/workflows/validate.yml)
+[![CodeQL](https://github.com/rsampayo/sleepme_thermostat/actions/workflows/codeql.yml/badge.svg)](https://github.com/rsampayo/sleepme_thermostat/actions/workflows/codeql.yml)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-[hacsbadge]: https://img.shields.io/badge/HACS-Custom_Repository-41BDF5.svg?style=for-the-badge
+> A Home Assistant custom integration for the **SleepMe Chilipad Dock Pro** bed-cooling system. Climate entity, water-level alert, connectivity sensor, and five diagnostic sensors — all backed by the [sleep.me developer API](https://docs.developer.sleep.me/api/).
 
-## Overview
+## Features
 
-The **SleepMe Dock Pro Integration** is a custom component for Home Assistant, designed to provide seamless control and automation for the Chilipad Dock Pro Bed Cooling System. This integration allows you to manage your sleep environment with precise temperature controls and real-time monitoring of your device's water level, ensuring optimal performance and comfort throughout the night.
+- Set bed temperature (13–48°C, half-degree steps, plus `Max Cool` / `Max Heat` presets per API contract).
+- Turn the device on/off via HVAC mode.
+- Water-level-low binary sensor for proactive alerts.
+- Connectivity binary sensor.
+- Five diagnostic sensors: IP, LAN, brightness, display unit, time zone.
+- Configurable polling interval (10–300 s).
+- Reauth flow when the API token rotates — no integration removal needed.
+- Multi-device support: configure multiple Dock Pros under one HA install.
+- Long-term statistics for brightness.
 
-## About the Chilipad Dock Pro Bed Cooling System
+## Requirements
 
-The [Chilipad Dock Pro](https://sleep.me/) is a cutting-edge bed cooling system that regulates your bed's temperature between 55°F and 115°F, ensuring you stay comfortable all night long, regardless of room temperature or your body’s heat load. The system uses water circulation to maintain your desired temperature, making it an effective solution for hot sleepers or those who want a cooler sleep environment.
+- Home Assistant Core **2026.1** or newer (tested on 2026.1, 2026.3, 2026.5).
+- A sleep.me account with at least one Dock Pro device.
+- A developer API token (generated in the sleep.me account portal, free).
 
 ## Installation
 
-### HACS Installation (Custom Repository)
+### HACS (recommended)
 
-1. Add the repository to HACS:
-   - Go to HACS in Home Assistant.
-   - Click the three dots in the top right corner and select "Custom repositories."
-   - Enter the repository URL: `https://github.com/rsampayo/sleepme_thermostat` and select "Integration."
-   - Click "Add."
-2. Install the integration from the HACS store.
+1. HACS → ⋮ → *Custom repositories* → add `https://github.com/rsampayo/sleepme_thermostat`, category *Integration*.
+2. Install **SleepMe Thermostat**.
 3. Restart Home Assistant.
-4. Add the integration via the Home Assistant UI.
+4. *Settings → Devices & Services → Add Integration → SleepMe Thermostat*.
 
-### Manual Installation
+### Manual
 
-1. Download the repository contents.
-2. Copy the `sleepme_thermostat` folder to your Home Assistant's `custom_components` directory.
+1. Download the repository.
+2. Copy `custom_components/sleepme_thermostat/` into `<config>/custom_components/`.
 3. Restart Home Assistant.
-4. Add the integration via the Home Assistant UI.
+4. Add the integration via the UI.
 
 ## Configuration
 
-1. Before configuring the integration, you need to obtain an authentication token from [Sleep.me](https://sleep.me/):
-   - Log in to your account on the Sleep.me website.
-   - Navigate to your account details.
-   - Go to the "Developer API" section.
-   - Create a new token.
+1. Generate an API token: sleep.me website → account → *Developer API* → *Create new token*.
+2. *Settings → Devices & Services → Add Integration → SleepMe Thermostat*.
+3. Paste the token; pick the device from the discovered list.
 
-2. After obtaining the token, navigate to the integrations page in Home Assistant.
-3. Click on "Add Integration" and search for "SleepMe Thermostat."
-4. Follow the on-screen instructions to complete the setup, where you'll need to enter the token you generated.
+To tune the polling cadence: *Settings → Devices & Services → SleepMe Thermostat → Configure → Poll interval*.
 
-## Usage
+## Entities created
 
-Once configured, you can use the SleepMe thermostat entity in your Home Assistant automations, scripts, and dashboards. The binary sensor provides real-time information on the water level in your Dock Pro, allowing you to automate alerts or actions when the water is low. Additionally, you can use this integration to adjust the temperature settings, either via the Home Assistant UI or through automation, to ensure your bed remains at the optimal temperature throughout the night.
+| Platform       | Entity                       | Notes                              |
+|----------------|------------------------------|------------------------------------|
+| climate        | Dock Pro *{name}*            | Target temp, on/off, Max Cool/Heat |
+| binary_sensor  | Water Level                  | Device class: PROBLEM              |
+| binary_sensor  | Connected                    | Device class: CONNECTIVITY         |
+| sensor         | IP Address                   | Diagnostic                         |
+| sensor         | LAN Address                  | Diagnostic                         |
+| sensor         | Brightness Level (%)         | Diagnostic, in long-term statistics |
+| sensor         | Display Temperature Unit     | Diagnostic                         |
+| sensor         | Time Zone                    | Diagnostic                         |
 
-## License
+## Example automation: cool the bed at bedtime
 
-This project is licensed under the [MIT License](LICENSE).
+```yaml
+automation:
+  - alias: SleepMe — cool bed at bedtime
+    trigger:
+      - platform: time
+        at: "22:30:00"
+    action:
+      - service: climate.set_hvac_mode
+        target:
+          entity_id: climate.dock_pro_ramon
+        data:
+          hvac_mode: auto
+      - service: climate.set_temperature
+        target:
+          entity_id: climate.dock_pro_ramon
+        data:
+          temperature: 18
+```
+
+## Troubleshooting
+
+**"API token rejected" / reauth banner keeps appearing.**
+Tokens can be rotated or revoked in the sleep.me developer portal. When that happens, the integration triggers a reauth prompt on *Settings → Devices & Services*. Click *Reauthenticate*, paste a fresh token, done. No HA restart needed.
+
+**"Cannot connect to SleepMe API."**
+The sleep.me API is aggressively rate-limited. Transient failures are normal — the integration honors `Retry-After` and recovers on the next poll. If the entity stays unavailable for more than a few minutes, check the log under `custom_components.sleepme_thermostat`.
+
+**Polling too aggressive / not aggressive enough.**
+The default poll interval is **20 seconds**. To change it: *Settings → Devices & Services → SleepMe Thermostat → Configure*. Acceptable range 10–300 s. Lower values feel snappier but consume more of your per-minute API budget.
+
+**Sharing a bug report.**
+Open the device page in *Settings → Devices & Services*, click ⋮, choose *Download diagnostics*. The downloaded JSON has your API token (and MAC, IP, serial) redacted. Attach it to a GitHub issue.
+
+**Adjusting log verbosity.**
+The integration registers one logger: `custom_components.sleepme_thermostat`. Use *Settings → System → Logs* or the `logger.set_level` service to bump it to debug temporarily.
+
+## Tested against
+
+| HA Core   | Python | Status |
+|-----------|--------|--------|
+| 2026.1.x  | 3.13   | tested |
+| 2026.3.x  | 3.14   | tested |
+| 2026.5.x  | 3.14   | tested |
+
+Older HA versions may work but are not in the CI matrix.
 
 ## Contributing
 
@@ -59,10 +119,6 @@ Contributions are welcome! Please open an issue or submit a pull request.
 
 When editing translations, edit `custom_components/sleepme_thermostat/strings.json` first (the source of truth), then copy verbatim to `custom_components/sleepme_thermostat/translations/en.json`. CI fails if the two files diverge. Other language files (e.g. `es.json`) are hand-maintained from `strings.json`.
 
-## Support
+## License
 
-If you encounter any issues or have questions, feel free to open an issue in the [GitHub repository](https://github.com/rsampayo/sleepme_thermostat).
-
-## Acknowledgments
-
-- Thanks to the Home Assistant community for their support and resources.
+[MIT](LICENSE).

--- a/custom_components/sleepme_thermostat/__init__.py
+++ b/custom_components/sleepme_thermostat/__init__.py
@@ -33,7 +33,6 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up SleepMe Thermostat from a config entry."""
-    api_url = entry.data.get("api_url") or API_URL
     api_token = entry.data.get("api_token")
     device_id = entry.data.get("device_id")
 
@@ -42,9 +41,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
 
-    client = SleepMeClient(hass, api_url, api_token, device_id)
+    client = SleepMeClient(hass, API_URL, api_token, device_id)
     coordinator = SleepMeUpdateManager(
-        hass, api_url, api_token, device_id, scan_interval=scan_interval
+        hass, API_URL, api_token, device_id, scan_interval=scan_interval
     )
 
     # First refresh propagates ConfigEntryAuthFailed (-> reauth flow) and
@@ -80,6 +79,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload the entry when its options change."""
     await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old config entries to the current schema.
+
+    v3 -> v4: drop `api_url` (always equals API_URL) and `name` (duplicates
+    the suffix of `entry.title`).
+    """
+    _LOGGER.debug(
+        "Migrating SleepMe entry %s from version %s", entry.entry_id, entry.version
+    )
+
+    if entry.version < 4:
+        new_data = {k: v for k, v in entry.data.items() if k not in ("api_url", "name")}
+        hass.config_entries.async_update_entry(entry, data=new_data, version=4)
+        _LOGGER.info(
+            "Migrated SleepMe entry %s to schema v4 (dropped api_url, name)",
+            entry.entry_id,
+        )
+
+    return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/sleepme_thermostat/binary_sensor.py
+++ b/custom_components/sleepme_thermostat/binary_sensor.py
@@ -32,15 +32,14 @@ async def async_setup_entry(
 ) -> None:
     """Set up SleepMe Thermostat binary sensors from a config entry."""
     device_id: str = entry.data["device_id"]
-    name: str = entry.data["name"]
     entry_data = hass.data[DOMAIN][entry.entry_id]
     coordinator = entry_data["coordinator"]
-    device_info = build_device_info(device_id, name, entry_data["device_info"])
+    device_info = build_device_info(device_id, entry.title, entry_data["device_info"])
 
     async_add_entities(
         [
-            WaterLevelLowSensor(coordinator, device_id, name, device_info),
-            DeviceConnectedBinarySensor(coordinator, device_id, name, device_info),
+            WaterLevelLowSensor(coordinator, device_id, device_info),
+            DeviceConnectedBinarySensor(coordinator, device_id, device_info),
         ]
     )
 
@@ -56,7 +55,6 @@ class WaterLevelLowSensor(CoordinatorEntity, BinarySensorEntity):
         self,
         coordinator: SleepMeUpdateManager,
         device_id: str,
-        name: str,
         device_info: DeviceInfo,
     ) -> None:
         super().__init__(coordinator)
@@ -82,7 +80,6 @@ class DeviceConnectedBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self,
         coordinator: SleepMeUpdateManager,
         device_id: str,
-        name: str,
         device_info: DeviceInfo,
     ) -> None:
         super().__init__(coordinator)

--- a/custom_components/sleepme_thermostat/climate.py
+++ b/custom_components/sleepme_thermostat/climate.py
@@ -71,15 +71,14 @@ async def async_setup_entry(
 ) -> None:
     """Set up SleepMe Thermostat climate entity from a config entry."""
     device_id: str = entry.data["device_id"]
-    name: str = entry.data["name"]
     entry_data = hass.data[DOMAIN][entry.entry_id]
     coordinator = entry_data["coordinator"]
-    device_info = build_device_info(device_id, name, entry_data["device_info"])
+    device_info = build_device_info(device_id, entry.title, entry_data["device_info"])
 
     _LOGGER.debug(
-        "[Device %s] Setting up SleepMeThermostat entity with name: %s",
+        "[Device %s] Setting up SleepMeThermostat entity (%s)",
         device_id,
-        name,
+        entry.title,
     )
     async_add_entities(
         [SleepMeThermostat(coordinator, entry_data["client"], device_id, device_info)]

--- a/custom_components/sleepme_thermostat/config_flow.py
+++ b/custom_components/sleepme_thermostat/config_flow.py
@@ -32,7 +32,7 @@ _LOGGER = logging.getLogger(__name__)
 class SleepMeThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for SleepMe Thermostat."""
 
-    VERSION = 3
+    VERSION = 4
 
     def __init__(self) -> None:
         self.api_token: str = ""
@@ -109,10 +109,8 @@ class SleepMeThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(
                     title=f"Dock Pro {name}",
                     data={
-                        "api_url": API_URL,
                         "api_token": self.api_token,
                         "device_id": device_id,
-                        "name": name,
                         "firmware_version": device_status.get("about", {}).get(
                             "firmware_version"
                         ),

--- a/custom_components/sleepme_thermostat/diagnostics.py
+++ b/custom_components/sleepme_thermostat/diagnostics.py
@@ -1,0 +1,66 @@
+"""Diagnostics support for SleepMe Thermostat.
+
+Exposed through HA's "Download diagnostics" UI on the device page.
+
+The api_token is redacted; everything else (coordinator data, entry options,
+device info) is included verbatim so support requests carry enough state to
+reproduce a bug without follow-up. MAC, IP, LAN, serial are also redacted by
+default to make the output safer to paste verbatim into a GitHub issue —
+narrow `TO_REDACT` if you need them visible during real debugging.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+TO_REDACT: set[str] = {
+    "api_token",
+    "mac_address",
+    "serial_number",
+    "ip_address",
+    "lan_address",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return a redacted diagnostic snapshot for a SleepMe config entry."""
+    entry_data = hass.data[DOMAIN].get(entry.entry_id, {})
+    coordinator = entry_data.get("coordinator")
+
+    coordinator_payload: dict[str, Any] = {}
+    if coordinator is not None:
+        coordinator_payload = {
+            "update_interval_seconds": (
+                coordinator.update_interval.total_seconds()
+                if coordinator.update_interval is not None
+                else None
+            ),
+            "last_update_success": coordinator.last_update_success,
+            "last_exception": (
+                repr(coordinator.last_exception)
+                if coordinator.last_exception is not None
+                else None
+            ),
+            "data": coordinator.data or {},
+        }
+
+    return {
+        "entry": {
+            "version": entry.version,
+            "title": entry.title,
+            "data": async_redact_data(dict(entry.data), TO_REDACT),
+            "options": dict(entry.options),
+        },
+        "device_info": async_redact_data(
+            dict(entry_data.get("device_info", {})), TO_REDACT
+        ),
+        "coordinator": async_redact_data(coordinator_payload, TO_REDACT),
+    }

--- a/custom_components/sleepme_thermostat/helpers.py
+++ b/custom_components/sleepme_thermostat/helpers.py
@@ -12,11 +12,15 @@ def round_half_up(n: float) -> float:
     return round(n * 2) / 2
 
 
-def build_device_info(device_id: str, name: str, info: dict) -> DeviceInfo:
-    """Construct the device_info dict shared by every platform."""
+def build_device_info(device_id: str, display_name: str, info: dict) -> DeviceInfo:
+    """Construct the device_info dict shared by every platform.
+
+    `display_name` is the full user-facing device name (e.g. "Dock Pro Ramon").
+    Callers typically pass `entry.title`.
+    """
     return DeviceInfo(
         identifiers={(DOMAIN, device_id)},
-        name=f"Dock Pro {name}",
+        name=display_name,
         manufacturer="SleepMe",
         model=info.get("model"),
         sw_version=info.get("firmware_version"),

--- a/custom_components/sleepme_thermostat/manifest.json
+++ b/custom_components/sleepme_thermostat/manifest.json
@@ -8,6 +8,8 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/rsampayo/sleepme_thermostat/issues",
+  "loggers": ["custom_components.sleepme_thermostat"],
+  "quality_scale": "silver",
   "requirements": [],
-  "version": "3.2.2"
+  "version": "4.0.0"
 }

--- a/custom_components/sleepme_thermostat/sensor.py
+++ b/custom_components/sleepme_thermostat/sensor.py
@@ -29,18 +29,17 @@ async def async_setup_entry(
 ) -> None:
     """Set up SleepMe Thermostat diagnostic sensors from a config entry."""
     device_id: str = entry.data["device_id"]
-    name: str = entry.data["name"]
     entry_data = hass.data[DOMAIN][entry.entry_id]
     coordinator = entry_data["coordinator"]
-    device_info = build_device_info(device_id, name, entry_data["device_info"])
+    device_info = build_device_info(device_id, entry.title, entry_data["device_info"])
 
     async_add_entities(
         [
-            IPAddressSensor(coordinator, device_id, name, device_info),
-            LANAddressSensor(coordinator, device_id, name, device_info),
-            BrightnessLevelSensor(coordinator, device_id, name, device_info),
-            DisplayTemperatureUnitSensor(coordinator, device_id, name, device_info),
-            TimeZoneSensor(coordinator, device_id, name, device_info),
+            IPAddressSensor(coordinator, device_id, device_info),
+            LANAddressSensor(coordinator, device_id, device_info),
+            BrightnessLevelSensor(coordinator, device_id, device_info),
+            DisplayTemperatureUnitSensor(coordinator, device_id, device_info),
+            TimeZoneSensor(coordinator, device_id, device_info),
         ]
     )
 
@@ -55,7 +54,6 @@ class _SleepMeDiagnosticSensor(CoordinatorEntity, SensorEntity):
         self,
         coordinator: SleepMeUpdateManager,
         device_id: str,
-        name: str,
         device_info: DeviceInfo,
         *,
         suffix: str,
@@ -77,13 +75,11 @@ class IPAddressSensor(_SleepMeDiagnosticSensor):
         self,
         coordinator: SleepMeUpdateManager,
         device_id: str,
-        name: str,
         device_info: DeviceInfo,
     ) -> None:
         super().__init__(
             coordinator,
             device_id,
-            name,
             device_info,
             suffix="ip_address",
             label="IP Address",
@@ -103,13 +99,11 @@ class LANAddressSensor(_SleepMeDiagnosticSensor):
         self,
         coordinator: SleepMeUpdateManager,
         device_id: str,
-        name: str,
         device_info: DeviceInfo,
     ) -> None:
         super().__init__(
             coordinator,
             device_id,
-            name,
             device_info,
             suffix="lan_address",
             label="LAN Address",
@@ -131,13 +125,11 @@ class BrightnessLevelSensor(_SleepMeDiagnosticSensor):
         self,
         coordinator: SleepMeUpdateManager,
         device_id: str,
-        name: str,
         device_info: DeviceInfo,
     ) -> None:
         super().__init__(
             coordinator,
             device_id,
-            name,
             device_info,
             suffix="brightness_level",
             label="Brightness Level",
@@ -157,13 +149,11 @@ class DisplayTemperatureUnitSensor(_SleepMeDiagnosticSensor):
         self,
         coordinator: SleepMeUpdateManager,
         device_id: str,
-        name: str,
         device_info: DeviceInfo,
     ) -> None:
         super().__init__(
             coordinator,
             device_id,
-            name,
             device_info,
             suffix="display_temperature_unit",
             label="Display Temperature Unit",
@@ -184,13 +174,11 @@ class TimeZoneSensor(_SleepMeDiagnosticSensor):
         self,
         coordinator: SleepMeUpdateManager,
         device_id: str,
-        name: str,
         device_info: DeviceInfo,
     ) -> None:
         super().__init__(
             coordinator,
             device_id,
-            name,
             device_info,
             suffix="time_zone",
             label="Time Zone",

--- a/custom_components/sleepme_thermostat/translations/es.json
+++ b/custom_components/sleepme_thermostat/translations/es.json
@@ -7,6 +7,9 @@
         "description": "Por favor, ingrese su token de API.",
         "data": {
           "api_token": "Token de API"
+        },
+        "data_description": {
+          "api_token": "Ingresa el token de API proporcionado por SleepMe."
         }
       },
       "select_device": {
@@ -14,6 +17,9 @@
         "description": "Seleccione el dispositivo Dock Pro que desea configurar.",
         "data": {
           "device_id": "ID del Dispositivo"
+        },
+        "data_description": {
+          "device_id": "Selecciona uno de los dispositivos detectados."
         }
       },
       "reauth_confirm": {
@@ -21,6 +27,9 @@
         "description": "Su token de API de SleepMe ya no es válido. Ingrese un nuevo token para volver a conectarse.",
         "data": {
           "api_token": "Token de API"
+        },
+        "data_description": {
+          "api_token": "Pega un token nuevo generado en la sección Developer API de SleepMe."
         }
       }
     },

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -161,6 +161,8 @@ This is where the historical latency problem actually gets fixed. **Detailed pla
 
 ### Phase 5 — Polish
 
+**Detailed plan: [`phase-5-polish.md`](./phase-5-polish.md).**
+
 | Status | Item |
 |--------|------|
 | ⬜ | Add `diagnostics.py` for HA's "Download diagnostics" button |

--- a/docs/phase-5-polish.md
+++ b/docs/phase-5-polish.md
@@ -1,0 +1,416 @@
+# Phase 5 — Polish & Release Plan
+
+**Status:** Drafted 2026-05-17, awaiting maintainer approval before execution.
+**Companion docs:** [`AUDIT.md`](./AUDIT.md), [`ROADMAP.md`](./ROADMAP.md), [`phase-0-foundation.md`](./phase-0-foundation.md), [`phase-1-p0-fixes.md`](./phase-1-p0-fixes.md), [`phase-2-modernization.md`](./phase-2-modernization.md), [`phase-3-climate-refactor.md`](./phase-3-climate-refactor.md), [`phase-4-testing.md`](./phase-4-testing.md).
+
+## Goal
+
+Take the integration from "refactor complete" to "v4.0.0 release ready." Concretely, after Phase 5:
+
+1. HA's *Download diagnostics* button works for any SleepMe entry — token redacted, coordinator snapshot included, structure stable across releases.
+2. `entry.data` has no dead state. `api_url` and `name` are removed; reads fall back to constants / `entry.title`. Old v3 entries auto-migrate.
+3. Spanish translation is back in sync with `strings.json`.
+4. `manifest.json` advertises `quality_scale: silver` and `loggers`, version bumps to `4.0.0`.
+5. README earns its top spot in the HACS store: badges, troubleshooting, an example automation, a version-support matrix.
+6. Two new tests cover diagnostics + migration. Coverage stays ≥ 80 %.
+
+Phase 5 is the **final phase of the audit-driven refactor.** It does not touch `climate.py`'s runtime path, the transport layer, or the testing matrix.
+
+## Cross-cutting concern: API budget per user action
+
+**Phase 5 is zero impact on the API call budget.** No transport, coordinator, or climate code paths change. Diagnostics is in-process, the schema migration runs once at HA startup against in-memory state, and the manifest/README changes are inert at runtime.
+
+## Scope
+
+| Source | File | Current | Phase 5 action |
+|---|---|---|---|
+| Audit P2 | new `diagnostics.py` | no diagnostics platform | Add `async_get_config_entry_diagnostics` with token redaction. |
+| Audit P2 | `__init__.py`, `config_flow.py`, `climate.py`, `binary_sensor.py`, `sensor.py`, `helpers.py` | `entry.data["api_url"]` always equals `API_URL`; `entry.data["name"]` duplicates entry.title suffix. Config flow `VERSION = 3`. | Drop both keys on new entries; `async_migrate_entry` rewrites old v3 entries; bump config flow `VERSION = 4`. |
+| Audit P2 | `translations/es.json` | Missing `data_description` blocks added in Phase 2. | Add the three missing keys (translated). |
+| Audit P2 | `manifest.json` | No `quality_scale`, no `loggers`. Version `3.2.2`. | Add `quality_scale: "silver"`, `loggers: [...]`. Bump `version` to `4.0.0`. |
+| Audit P2 | `README.md` | 67 lines. No CI badges, no troubleshooting, no example automation. | Rewrite to ≤ 200 lines with badges, feature list, troubleshooting, automation example, version matrix. |
+| Implicit gap | `tests/test_diagnostics.py` (new) | none | 2 tests: redaction + structure. |
+| Implicit gap | `tests/test_init.py` | v3 fixture only | Add `test_migrate_entry_v3_to_v4`. |
+
+## Deliverables
+
+### 1. Diagnostics platform
+
+**File:** `custom_components/sleepme_thermostat/diagnostics.py` (new, ~50 LOC). HA discovers `diagnostics.py` automatically.
+
+```python
+"""Diagnostics support for SleepMe Thermostat."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+TO_REDACT: set[str] = {
+    "api_token",
+    "mac_address",
+    "serial_number",
+    "ip_address",
+    "lan_address",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return a redacted diagnostic snapshot for a SleepMe config entry."""
+    entry_data = hass.data[DOMAIN].get(entry.entry_id, {})
+    coordinator = entry_data.get("coordinator")
+
+    coordinator_payload: dict[str, Any] = {}
+    if coordinator is not None:
+        coordinator_payload = {
+            "update_interval_seconds": (
+                coordinator.update_interval.total_seconds()
+                if coordinator.update_interval is not None
+                else None
+            ),
+            "last_update_success": coordinator.last_update_success,
+            "last_exception": (
+                repr(coordinator.last_exception)
+                if coordinator.last_exception is not None
+                else None
+            ),
+            "data": coordinator.data or {},
+        }
+
+    return {
+        "entry": {
+            "version": entry.version,
+            "title": entry.title,
+            "data": async_redact_data(dict(entry.data), TO_REDACT),
+            "options": dict(entry.options),
+        },
+        "device_info": async_redact_data(
+            dict(entry_data.get("device_info", {})), TO_REDACT
+        ),
+        "coordinator": async_redact_data(coordinator_payload, TO_REDACT),
+    }
+```
+
+Defensive redaction of MAC/IP/LAN/serial — easier to share diagnostics verbatim.
+
+### 2. `entry.data` schema migration v3 → v4
+
+**Files:** `config_flow.py`, `__init__.py`, `helpers.py`, `climate.py`, `binary_sensor.py`, `sensor.py`, `tests/test_init.py`, `tests/test_config_flow.py`.
+
+**Decision: `build_device_info` accepts the full display name (`entry.title`)**, dropping the `"Dock Pro "` prefix composition from `helpers.py`. Cleaner and matches HA's device-registry convention.
+
+#### config_flow.py
+
+```diff
+-    VERSION = 3
++    VERSION = 4
+```
+
+```diff
+                 return self.async_create_entry(
+                     title=f"Dock Pro {name}",
+                     data={
+-                        "api_url": API_URL,
+                         "api_token": self.api_token,
+                         "device_id": device_id,
+-                        "name": name,
+                         "firmware_version": ...
+                     },
+                 )
+```
+
+#### __init__.py — add async_migrate_entry
+
+```python
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old config entries to the current schema.
+
+    v3 -> v4: drop `api_url` and `name` (both dead state).
+    """
+    _LOGGER.debug(
+        "Migrating SleepMe entry %s from version %s", entry.entry_id, entry.version
+    )
+
+    if entry.version < 4:
+        new_data = {k: v for k, v in entry.data.items() if k not in ("api_url", "name")}
+        hass.config_entries.async_update_entry(entry, data=new_data, version=4)
+        _LOGGER.info(
+            "Migrated SleepMe entry %s to schema v4 (dropped api_url, name)",
+            entry.entry_id,
+        )
+
+    return True
+```
+
+Simplify async_setup_entry: use `API_URL` constant directly; no more `entry.data["api_url"]`.
+
+#### helpers.py — drop "Dock Pro " prefix
+
+```diff
+-def build_device_info(device_id: str, name: str, info: dict) -> DeviceInfo:
++def build_device_info(device_id: str, display_name: str, info: dict) -> DeviceInfo:
+     return DeviceInfo(
+         identifiers={(DOMAIN, device_id)},
+-        name=f"Dock Pro {name}",
++        name=display_name,
+         ...
+     )
+```
+
+#### Platforms — pass `entry.title`
+
+```diff
+-    name: str = entry.data["name"]
+     ...
+-    device_info = build_device_info(device_id, name, entry_data["device_info"])
++    device_info = build_device_info(
++        device_id, entry.title, entry_data["device_info"]
++    )
+```
+
+Entity constructors (binary_sensor, sensor) drop their unused `name` parameter (5 sensor classes + 2 binary sensor classes = 7 call sites).
+
+#### Tests
+
+```python
+async def test_migrate_entry_v3_to_v4(hass, mock_sleepme_client):
+    """A v3 entry auto-migrates to v4: api_url and name removed."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        data={
+            "api_url": API_URL,
+            "api_token": MOCK_API_TOKEN,
+            "device_id": MOCK_DEVICE_ID,
+            "name": MOCK_NAME,
+            # ... other v3 fields
+        },
+        ...
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.version == 4
+    assert "api_url" not in entry.data
+    assert "name" not in entry.data
+```
+
+Also: `test_happy_path` asserts no `api_url`/`name` in newly created entries.
+
+### 3. ES translation re-sync
+
+Three missing `data_description` blocks. Add to `translations/es.json`:
+
+```diff
+       "user": {
+         "data": { "api_token": "Token de API" }
++        ,"data_description": {
++          "api_token": "Ingresa el token de API proporcionado por SleepMe."
++        }
+       },
+       "select_device": {
+         "data": { "device_id": "ID del Dispositivo" }
++        ,"data_description": {
++          "device_id": "Selecciona uno de los dispositivos detectados."
++        }
+       },
+       "reauth_confirm": {
+         "data": { "api_token": "Token de API" }
++        ,"data_description": {
++          "api_token": "Pega un token nuevo generado en la sección Developer API de SleepMe."
++        }
+       }
+```
+
+Key-set parity check (run locally before commit):
+
+```bash
+python -c "
+import json
+en = json.load(open('custom_components/sleepme_thermostat/translations/en.json'))
+es = json.load(open('custom_components/sleepme_thermostat/translations/es.json'))
+
+def flat(d, prefix=''):
+    out = set()
+    for k, v in d.items():
+        path = f'{prefix}.{k}' if prefix else k
+        if isinstance(v, dict):
+            out |= flat(v, path)
+        else:
+            out.add(path)
+    return out
+
+print('Missing in ES:', sorted(flat(en) - flat(es)))
+print('Missing in EN:', sorted(flat(es) - flat(en)))
+"
+```
+
+### 4. quality_scale: silver
+
+Silver requirements check (all met after Phases 0–4 + Phase 5 deliverables 1 + 2):
+
+| Silver requirement | Status |
+|---|---|
+| `_attr_has_entity_name = True` | ✅ Phase 2 |
+| Reauth flow | ✅ Phase 1 |
+| Options flow | ✅ Phase 2 |
+| `ConfigEntryAuthFailed`, `UpdateFailed` | ✅ Phase 1 |
+| Test coverage ≥ 80% | ✅ Phase 4 (89%) |
+| `device_info` complete | ✅ |
+| Unique IDs on every entity | ✅ |
+| Translation files (en + es) | ✅ after deliverable 3 |
+| `strings.json` source of truth | ✅ Phase 2 |
+| Diagnostics platform | ✅ deliverable 1 |
+| `loggers` in manifest | ✅ deliverable 5 |
+| `async_unload_entry` | ✅ Phase 1 |
+| `async_migrate_entry` | ✅ deliverable 2 |
+
+**Gold** is out of reach: requires device discovery (zeroconf/SSDP), but SleepMe is cloud-only.
+
+### 5. manifest.json updates
+
+```diff
+ {
+   "domain": "sleepme_thermostat",
+   "name": "SleepMe Thermostat",
+   "codeowners": ["@rsampayo", "@mikesalz","@derekcentrico"],
+   "config_flow": true,
+   "dependencies": [],
+   "documentation": "https://github.com/rsampayo/sleepme_thermostat",
+   "integration_type": "device",
+   "iot_class": "cloud_polling",
+   "issue_tracker": "https://github.com/rsampayo/sleepme_thermostat/issues",
++  "loggers": ["custom_components.sleepme_thermostat"],
++  "quality_scale": "silver",
+   "requirements": [],
+-  "version": "3.2.2"
++  "version": "4.0.0"
+ }
+```
+
+### 6. README polish
+
+Target: ≤ 200 lines. Sections:
+
+```
+# SleepMe Dock Pro Integration
+[badges]
+> One-sentence summary
+
+## Features
+## Requirements
+## Installation (HACS / manual)
+## Configuration
+## Entities (table)
+## Example automation: cool at bedtime
+## Troubleshooting
+## Tested against
+## Contributing
+## License
+```
+
+Badges (top of file):
+- HACS Custom Repository
+- Quality Scale (silver)
+- License (MIT)
+- Test workflow status
+- Validate HACS status
+- CodeQL status
+- Ruff
+
+Troubleshooting bullets cover: reauth flow, rate-limit handling, scan_interval tuning, downloading diagnostics, log verbosity.
+
+### 7. Version bump to 4.0.0
+
+Rationale baked into deliverable 5's manifest diff. Major bump signals cumulative behavior change across phases:
+- Phase 1: reauth flow, unload, multi-device fix.
+- Phase 2: has_entity_name (UI label composition changed).
+- Phase 3: slider semantics (optimistic state).
+- Phase 5: entry.data schema (auto-migrated).
+
+Tag `v4.0.0`. Release notes link to each `phase-N-*.md` doc.
+
+### 8. Tests
+
+`tests/test_diagnostics.py`:
+- `test_diagnostics_redacts_token` — `diag["entry"]["data"]["api_token"] == "**REDACTED**"`; other keys survive.
+- `test_diagnostics_structure` — top-level keys are `entry`/`device_info`/`coordinator`; coordinator payload has expected fields.
+
+`tests/test_init.py::test_migrate_entry_v3_to_v4` — set up a v3 entry, assert migration to v4 happened on setup.
+
+**Coverage delta:** `diagnostics.py` 0 → ~95%; migration path covered.
+
+## Validation against live device
+
+| # | Step | Pass criterion |
+|---|------|----------------|
+| 1 | `pytest --cov-fail-under=80` locally | Green. |
+| 2 | `pre-commit run --all-files` | Green. |
+| 3 | All CI matrix jobs | Green. |
+| 4 | `make deploy-restart HA_HOST=100.88.154.98` | Exit 0. |
+| 5 | Entity registry continuity (`before.txt` / `after.txt`) | `diff -q` empty. |
+| 6 | Migration log line | `"Migrated SleepMe entry <id> to schema v4"` appears once per existing entry. |
+| 7 | Storage inspection | `api_url` and `name` absent from `.storage/core.config_entries` sleepme entries; `version: 4`. |
+| 8 | "Download diagnostics" | JSON downloads; `api_token == "**REDACTED**"`; `coordinator.data` shape correct. |
+| 9 | Options flow still works | No regression. |
+| 10 | Reauth still works | No regression. |
+| 11 | README badges render on GitHub | All images load. |
+| 12 | HACS panel shows v4.0.0 | After tag push. |
+
+## Acceptance / exit criteria
+
+- [ ] `diagnostics.py` exists; redaction set documented.
+- [ ] `manifest.json` has `quality_scale: "silver"`, `loggers`, `version: "4.0.0"`.
+- [ ] `config_flow.py` `VERSION = 4`; no `api_url` or `name` in new entries.
+- [ ] `async_migrate_entry` covers v3 → v4.
+- [ ] `build_device_info` accepts full display name; "Dock Pro " composition removed.
+- [ ] All platforms pass `entry.title` to `build_device_info`.
+- [ ] Entity constructors no longer take `name` parameter.
+- [ ] `translations/es.json` parity with EN; key-set diff empty.
+- [ ] `README.md` ≤ 200 lines; full Phase 5 outline.
+- [ ] `tests/test_diagnostics.py` (2 tests) + `test_migrate_entry_v3_to_v4` exist and pass.
+- [ ] `pytest --cov-fail-under=80` green.
+- [ ] Live-host validation 4–10 done; results in PR description.
+- [ ] All CI jobs green.
+- [ ] `docs/ROADMAP.md` Phase 5 row flipped ⬜ → ✅.
+- [ ] Git tag `v4.0.0` + release notes.
+
+## Risks and open questions
+
+1. **Redacting MAC/serial/IP** — defensible default (easier to share verbatim), but hides identifiers during real debugging. **Decision: redact by default.** Narrow to `{"api_token"}` only if maintainer disagrees.
+
+2. **Disabled entries don't migrate until enabled.** Both test-host entries (`Ramon`, `Chiva`) are `disabled_by: user`. Migration fires when re-enabled or on next HA restart with them enabled.
+
+3. **`async_redact_data` sentinel string drift.** Currently `"**REDACTED**"` in HA core. Test asserts the literal; if HA changes it, CI catches the divergence.
+
+4. **README badge URLs** assume `rsampayo/sleepme_thermostat`. Quality Scale badge is hand-rolled.
+
+5. **`hass.data` shape for half-loaded entries** — diagnostics function handles missing-entry case via `.get(entry.entry_id, {})`. No crash on `SETUP_RETRY` entries.
+
+## Out of scope (explicit)
+
+| Item | Decision |
+|---|---|
+| `TypedDict` for `device_info` payload | Optional Phase 6. Strict mypy already type-checks it. |
+| Drop `RUF012` from ignore list | Wait for HA framework change. |
+| Upgrade `ruff` version | Separate `chore(deps)` PR. |
+| Multi-device discovery / zeroconf for Gold | SleepMe is cloud-only. |
+| Python 3.12 in matrix | Deferred. |
+| HA `dev` channel in matrix | Deferred. |
+| Coverage threshold > 80% | Phase 4 settled. |
+
+## Optional Phase 6 follow-ups
+
+1. **`TypedDict` for device_info payload.** Strong typing for the `entry_data["device_info"]` dict that flows through the integration.
+2. **CI EN/ES key-set parity check** as a workflow job.
+3. **Drop `E731` from ruff ignore** (Phase 3 verify-loop is gone; the lambdas it justified no longer exist).
+4. **Per-integration `quality_scale.yaml`** enumerating evaluated criteria.
+5. **Re-audit** — refresh `AUDIT.md` after a release shipping cycle; many P1 findings now closed.

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,86 @@
+"""Tests for the diagnostics platform."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from custom_components.sleepme_thermostat.const import DOMAIN
+from custom_components.sleepme_thermostat.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from tests.const import MOCK_API_TOKEN, MOCK_DEVICE_ID, MOCK_NAME
+
+
+def _make_v4_entry() -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="entry_diag",
+        version=4,
+        unique_id=MOCK_DEVICE_ID,
+        title=f"Dock Pro {MOCK_NAME}",
+        data={
+            "api_token": MOCK_API_TOKEN,
+            "device_id": MOCK_DEVICE_ID,
+            "firmware_version": "0.0.0-test",
+            "mac_address": "aa:bb:cc:dd:ee:ff",
+            "model": "Dock Pro",
+            "serial_number": "TEST-SERIAL",
+        },
+        options={"scan_interval": 30},
+    )
+
+
+async def test_diagnostics_redacts_token(
+    hass: HomeAssistant, mock_sleepme_client: AsyncMock
+) -> None:
+    """The api_token is replaced with the redaction sentinel."""
+    entry = _make_v4_entry()
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diag["entry"]["data"]["api_token"] == "**REDACTED**"
+    # Non-secret keys survive.
+    assert diag["entry"]["data"]["device_id"] == MOCK_DEVICE_ID
+    # mac_address is in TO_REDACT (defensive); should also be redacted.
+    assert diag["entry"]["data"]["mac_address"] == "**REDACTED**"
+
+
+async def test_diagnostics_structure(
+    hass: HomeAssistant, mock_sleepme_client: AsyncMock
+) -> None:
+    """Top-level keys are stable; coordinator snapshot is present."""
+    entry = _make_v4_entry()
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert set(diag.keys()) == {"entry", "device_info", "coordinator"}
+    assert diag["entry"]["version"] == 4
+    assert diag["entry"]["title"] == f"Dock Pro {MOCK_NAME}"
+    assert diag["entry"]["options"]["scan_interval"] == 30
+    assert diag["coordinator"]["last_update_success"] is True
+    assert diag["coordinator"]["update_interval_seconds"] == 30
+    assert set(diag["coordinator"]["data"].keys()) == {"status", "control", "about"}
+
+
+async def test_diagnostics_handles_missing_entry_data(
+    hass: HomeAssistant,
+) -> None:
+    """If entry never reached setup, diagnostics still returns gracefully."""
+    entry = _make_v4_entry()
+    # Note: NOT calling async_setup — entry is registered but not loaded.
+    entry.add_to_hass(hass)
+    hass.data.setdefault(DOMAIN, {})
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diag["entry"]["data"]["api_token"] == "**REDACTED**"
+    assert diag["coordinator"] == {}

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -25,7 +25,9 @@ def test_build_device_info_shape():
         "mac_address": "aa:bb:cc:dd:ee:ff",
         "serial_number": "SN-1",
     }
-    out = build_device_info("dev-1", "Ramon", info)
+    # Phase 5: build_device_info now accepts the full display name verbatim
+    # (callers pass entry.title), so "Dock Pro Ramon" goes in unchanged.
+    out = build_device_info("dev-1", "Dock Pro Ramon", info)
     assert out["identifiers"] == {(DOMAIN, "dev-1")}
     assert out["name"] == "Dock Pro Ramon"
     assert out["manufacturer"] == "SleepMe"
@@ -42,7 +44,7 @@ def test_build_device_info_shape():
 
 def test_build_device_info_handles_missing_keys():
     """Missing keys flow through as None — HA tolerates this."""
-    out = build_device_info("dev-2", "Chiva", {})
+    out = build_device_info("dev-2", "Dock Pro Chiva", {})
     assert out["model"] is None
     assert out["sw_version"] is None
     assert out["serial_number"] is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -103,3 +103,39 @@ async def test_multi_entry_isolation(
     assert entry_b.state is ConfigEntryState.LOADED
     assert "entry_a" not in hass.data[DOMAIN]
     assert "entry_b" in hass.data[DOMAIN]
+
+
+async def test_migrate_entry_v3_to_v4(
+    hass: HomeAssistant, mock_sleepme_client: AsyncMock
+) -> None:
+    """A v3 entry auto-migrates to v4: api_url and name removed; version bumps."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="entry_v3",
+        version=3,
+        unique_id=MOCK_DEVICE_ID,
+        title=f"Dock Pro {MOCK_NAME}",
+        data={
+            "api_url": API_URL,
+            "api_token": MOCK_API_TOKEN,
+            "device_id": MOCK_DEVICE_ID,
+            "name": MOCK_NAME,
+            "firmware_version": "0.0.0-test",
+            "mac_address": "aa:bb:cc:dd:ee:ff",
+            "model": "Dock Pro",
+            "serial_number": "TEST-SERIAL",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.version == 4
+    assert "api_url" not in entry.data
+    assert "name" not in entry.data
+    # Other keys survive untouched.
+    assert entry.data["device_id"] == MOCK_DEVICE_ID
+    assert entry.data["api_token"] == MOCK_API_TOKEN
+    assert entry.title == f"Dock Pro {MOCK_NAME}"


### PR DESCRIPTION
## Summary

Final phase of the audit-driven refactor — five-phase journey concludes with a release-ready v4.0.0. Closes audit P2 items.

**Verified end-to-end on the live Dock Pro host:**
- All 3 sleepme entries (Ramon, Chiva, legacy tracker) auto-migrated from v3 to v4 on HA restart. Migration log: `Migrated SleepMe entry <id> to schema v4 (dropped api_url, name)`.
- Storage inspection confirms `api_url` and `name` are gone from all 3 entries; `version: 4`.
- Entity IDs identical before/after — zero automation breakage.
- 55 tests pass locally; coverage 89.51%; mypy clean with strict flags.

## Changes

- **`diagnostics.py`** (new) — `async_get_config_entry_diagnostics` returns a redacted snapshot. `api_token`, `mac_address`, `serial_number`, `ip_address`, `lan_address` all replaced with `**REDACTED**`. HA's "Download diagnostics" button now works.
- **Schema migration v3 → v4** — `async_migrate_entry` drops `api_url` (always equaled `API_URL` constant) and `name` (duplicated `entry.title` suffix). Config flow `VERSION = 4`; new entries no longer write those keys.
- **`build_device_info` accepts full display name** — callers pass `entry.title` directly; `"Dock Pro "` prefix composition removed from `helpers.py`. Platform entity constructors drop the now-unused `name` parameter (7 call sites cleaned up).
- **manifest.json** — `quality_scale: silver` (Gold requires device discovery, not possible for cloud-only SleepMe), `loggers: ["custom_components.sleepme_thermostat"]`, `version: 4.0.0`.
- **ES translation re-sync** — 3 missing `data_description` blocks added (`user.api_token`, `select_device.device_id`, `reauth_confirm.api_token`).
- **README rewrite** — ≤200 lines: 7 CI badges, feature list, requirements, install/configuration, entity table, example automation, troubleshooting, tested-against matrix.

## Tests added (+4 → 55 total)

- `tests/test_diagnostics.py` (3 tests) — redaction sentinel, top-level structure, half-loaded entry tolerance.
- `tests/test_init.py::test_migrate_entry_v3_to_v4` — full v3 fixture loads, asserts `api_url`/`name` removed, `version` bumped to 4.
- `tests/test_helpers.py` — updated for new `build_device_info` signature.

## Test plan

- [x] `pytest --cov-fail-under=80` — 55 passed, coverage 89.51%.
- [x] `mypy custom_components/sleepme_thermostat` — 0 errors with strict flags.
- [x] `pre-commit run --all-files` clean.
- [x] `make deploy-restart HA_HOST=100.88.154.98` succeeds.
- [x] Entity IDs identical before/after (`diff -q` empty, 24 entities).
- [x] Migration log line appeared for all 3 entries on first start after deploy.
- [x] Storage inspection: `api_url` and `name` absent from all 3 entries; `version: 4`.
- [ ] CI matrix green (Test×3 HA versions, mypy, lint, i18n-check, HACS, CodeQL).
- [ ] After merge: tag `v4.0.0` and write release notes linking to each phase doc.

## Quality scale: silver

After Phase 5, the integration meets every Silver criterion: reauth flow (Phase 1), options flow (Phase 2), `has_entity_name` (Phase 2), `ConfigEntryAuthFailed`/`UpdateFailed` (Phase 1), test coverage ≥80% (Phase 4), translations (en+es), `strings.json` source of truth (Phase 2), diagnostics platform (this phase), `loggers` in manifest (this phase), `async_unload_entry` (Phase 1), `async_migrate_entry` (this phase).

Gold is intentionally out of reach: requires device discovery (zeroconf/SSDP), but SleepMe Dock Pro is cloud-only.

## Notes for v4.0.0 release

Major version bump signals the cumulative behavior change across five phases:
- Phase 1 reauth + multi-device fix
- Phase 2 `has_entity_name` (UI label composition)
- Phase 3 slider semantics (optimistic state)
- Phase 5 schema v3→v4 migration

All changes are auto-migrating; no user action required beyond restart-on-update.

See `docs/phase-5-polish.md` for the detailed plan, and `docs/ROADMAP.md` for the full audit trail across all 5 phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)