### PR TITLE
fix(rate-limit): absorb window-edge jitter; default scan_interval 30s; v4.1.1

### DIFF
--- a/custom_components/sleepme_thermostat/const.py
+++ b/custom_components/sleepme_thermostat/const.py
@@ -16,6 +16,9 @@ MAX_TEMP_C = 48.0
 
 # Options flow
 CONF_SCAN_INTERVAL = "scan_interval"
-DEFAULT_SCAN_INTERVAL = 20
+# 30s default keeps 3-device installs comfortably under the 9 req/min
+# per-account ceiling (3 * 60/30 = 6 req/min). v4.1.0 release notes asked
+# multi-device users to bump this manually; v4.1.1 makes it the default.
+DEFAULT_SCAN_INTERVAL = 30
 MIN_SCAN_INTERVAL = 10
 MAX_SCAN_INTERVAL = 300

--- a/custom_components/sleepme_thermostat/manifest.json
+++ b/custom_components/sleepme_thermostat/manifest.json
@@ -11,5 +11,5 @@
   "loggers": ["custom_components.sleepme_thermostat"],
   "quality_scale": "silver",
   "requirements": [],
-  "version": "4.1.0"
+  "version": "4.1.1"
 }

--- a/custom_components/sleepme_thermostat/sleepme_api.py
+++ b/custom_components/sleepme_thermostat/sleepme_api.py
@@ -36,6 +36,12 @@ _LOGGER = logging.getLogger(__name__)
 
 MAX_REQUESTS_PER_MINUTE = 9
 RATE_LIMIT_WINDOW = 60  # seconds
+# Edge grace: when the deque is at capacity but the oldest entry is within this
+# many seconds of expiring, absorb the wait in-call instead of raising. Prevents
+# benign timing skew at the window boundary from cascading into UpdateFailed +
+# entity-flap when an install sits at the per-account ceiling (e.g. 3 devices
+# polling at 20s = 9 req/min exactly).
+RATE_LIMIT_EDGE_GRACE = 5.0  # seconds
 DEFAULT_RETRIES = 3
 BACKOFF_BASE_429 = 30  # seconds
 BACKOFF_BASE_5XX = 10  # seconds
@@ -190,10 +196,14 @@ class SleepMeAPI:
                 ) from err
 
     async def _enforce_local_rate_limit(self, method: str, endpoint: str) -> None:
-        """Record the request or raise SleepMeRateLimited.
+        """Record the request, briefly wait at the window edge, or raise.
 
         Sliding window: drop entries older than RATE_LIMIT_WINDOW, then check
-        capacity. We deliberately do NOT queue — caller decides what to do.
+        capacity. If at capacity but the wait is small (<= RATE_LIMIT_EDGE_GRACE)
+        we sleep in-call — multi-device installs sitting at the per-account
+        ceiling routinely tip a few ms past the edge, and turning that into an
+        ERROR + UpdateFailed every cycle is the worst kind of log noise. Larger
+        waits still raise: caller decides.
         """
         async with self._lock:
             now = time.monotonic()
@@ -206,6 +216,22 @@ class SleepMeAPI:
             maxlen = self._request_times.maxlen
             if maxlen is not None and len(self._request_times) >= maxlen:
                 wait = RATE_LIMIT_WINDOW - (now - self._request_times[0])
+                if wait <= RATE_LIMIT_EDGE_GRACE:
+                    _LOGGER.debug(
+                        "Local rate-limit edge on %s %s; waiting %.3fs in-call",
+                        method,
+                        endpoint,
+                        wait,
+                    )
+                    await asyncio.sleep(max(wait, 0.0))
+                    now = time.monotonic()
+                    while (
+                        self._request_times
+                        and now - self._request_times[0] >= RATE_LIMIT_WINDOW
+                    ):
+                        self._request_times.popleft()
+                    self._request_times.append(now)
+                    return
                 _LOGGER.warning(
                     "Local rate limit hit on %s %s; would need %.1fs. Rejecting.",
                     method,

--- a/tests/test_sleepme_api.py
+++ b/tests/test_sleepme_api.py
@@ -10,6 +10,8 @@ import pytest
 from custom_components.sleepme_thermostat.sleepme_api import (
     BACKOFF_BASE_429,
     MAX_REQUESTS_PER_MINUTE,
+    RATE_LIMIT_EDGE_GRACE,
+    RATE_LIMIT_WINDOW,
     SleepMeAPI,
     SleepMeAuthError,
     SleepMeRateLimited,
@@ -110,6 +112,49 @@ async def test_get_under_rate_limit_raises(api: SleepMeAPI) -> None:
     now = time.monotonic()
     for _ in range(MAX_REQUESTS_PER_MINUTE):
         api._request_times.append(now)
+
+    with pytest.raises(SleepMeRateLimited):
+        await api.api_request("GET", "devices", retries=0)
+
+
+async def test_window_edge_waits_briefly_instead_of_raising(
+    api: SleepMeAPI,
+) -> None:
+    """Deque at capacity but oldest within RATE_LIMIT_EDGE_GRACE: sleep, proceed.
+
+    Models the steady-state for a 3-device install at 20s polling: cumulative
+    9 req/min sits exactly at the per-account ceiling, so the next call lands
+    a few ms past the window edge. v4.1.1 absorbs that in-call.
+    """
+    # Oldest entry is 59s old -> wait would be ~1s, within the 5s grace.
+    edge_age = RATE_LIMIT_WINDOW - 1.0
+    base = time.monotonic() - edge_age
+    for _ in range(MAX_REQUESTS_PER_MINUTE):
+        api._request_times.append(base)
+
+    final_ok = MagicMock()
+    final_ok.raise_for_status = MagicMock()
+    final_ok.json = MagicMock(return_value={"ok": True})
+    api.client.request.return_value = final_ok
+
+    with patch(
+        "custom_components.sleepme_thermostat.sleepme_api.asyncio.sleep",
+        new_callable=AsyncMock,
+    ) as mock_sleep:
+        result = await api.api_request("GET", "devices", retries=0)
+
+    assert result == {"ok": True}
+    assert mock_sleep.await_count == 1
+    waited = mock_sleep.await_args_list[0].args[0]
+    assert 0.0 <= waited <= RATE_LIMIT_EDGE_GRACE
+
+
+async def test_wait_above_grace_still_raises(api: SleepMeAPI) -> None:
+    """Deque at capacity with oldest well inside window still raises."""
+    # Oldest entry is 30s old -> wait ~30s, far above the grace.
+    base = time.monotonic() - 30.0
+    for _ in range(MAX_REQUESTS_PER_MINUTE):
+        api._request_times.append(base)
 
     with pytest.raises(SleepMeRateLimited):
         await api.api_request("GET", "devices", retries=0)


### PR DESCRIPTION
## Summary

- Multi-device installs at the per-account ceiling (e.g. 3 devices × 20s = 9 req/min, exactly `MAX_REQUESTS_PER_MINUTE`) routinely tipped a few ms past the 60s sliding window and got `SleepMeRateLimited` on every poll. Validation HA logged **2,608 `UpdateFailed` errors over 2.5 days** — the dominant noise source.
- `sleepme_api.py`: when the deque is at capacity but the wait is ≤ `RATE_LIMIT_EDGE_GRACE` (5s), `await asyncio.sleep(wait)` in-call. Logs at DEBUG. Waits beyond grace still raise.
- `const.py`: bump `DEFAULT_SCAN_INTERVAL` 20→30. The v4.1.0 release notes already advised this for multi-device installs; this closes the gap for users who never visit *Configure*.
- `manifest.json`: 4.1.0 → 4.1.1.

## Why this design

- The Phase 1 / 6 contract was "raise on rate-limit, never queue indefinitely." That's still right for *real* overload. A near-edge wait of milliseconds is not overload — it's clock skew at the per-account ceiling.
- Holding the rate-limiter lock during the short sleep serializes concurrent callers, which is the desired behavior (they queue in order). HTTP is *outside* the lock; throughput is unchanged.
- Default `scan_interval = 30s` is a no-op for entries with an explicit option (`entry.options.get(CONF_SCAN_INTERVAL, ...)`).

## Test plan

- [x] `pytest --cov` — 59 passed, 89.4% coverage (was 57 / 89%)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy custom_components/sleepme_thermostat` clean
- [ ] `make deploy-restart HA_HOST=100.88.154.98` and confirm the `Local rate limit hit` cascade disappears from `home-assistant.log` after one full polling cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced rate limiter to gracefully handle edge-of-window requests, reducing false rate-limit failures when managing multiple devices.
  * Updated default scan interval from 20 to 30 seconds for improved multi-device compatibility and stability.

* **Chores**
  * Version bumped to v4.1.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rsampayo/sleepme_thermostat/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->