### PR TITLE
fix: block gen-2 (x2-) devices in config flow

### DIFF
--- a/custom_components/sleepme_thermostat/config_flow.py
+++ b/custom_components/sleepme_thermostat/config_flow.py
@@ -18,6 +18,7 @@ from .const import (
     DOMAIN,
     MAX_SCAN_INTERVAL,
     MIN_SCAN_INTERVAL,
+    UNSUPPORTED_DEVICE_ID_PREFIXES,
 )
 from .sleepme import SleepMeClient
 from .sleepme_api import (
@@ -99,37 +100,45 @@ class SleepMeThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             device_id = user_input["device_id"]
             name = self._claimed_devices_dict[device_id]
 
-            await self.async_set_unique_id(device_id)
-            self._abort_if_unique_id_configured()
+            if device_id.startswith(UNSUPPORTED_DEVICE_ID_PREFIXES):
+                # Gen-2 / Chilipad 2.0 ("x2-") devices: the sleep.me v1 API
+                # rejects these IDs with HTTP 400 and the v2 surface returns 403
+                # for developer tokens, so we can read neither status nor control
+                # them yet. Block with a clear message instead of a generic
+                # fetch error. See issue #46.
+                errors["base"] = "unsupported_gen2_device"
+            else:
+                await self.async_set_unique_id(device_id)
+                self._abort_if_unique_id_configured()
 
-            client = SleepMeClient(self.hass, API_URL, self.api_token, device_id)
+                client = SleepMeClient(self.hass, API_URL, self.api_token, device_id)
 
-            try:
-                device_status = await client.get_device_status()
-                return self.async_create_entry(
-                    title=f"Dock Pro {name}",
-                    data={
-                        "api_token": self.api_token,
-                        "device_id": device_id,
-                        "firmware_version": device_status.get("about", {}).get(
-                            "firmware_version"
-                        ),
-                        "mac_address": device_status.get("about", {}).get(
-                            "mac_address"
-                        ),
-                        "model": device_status.get("about", {}).get("model"),
-                        "serial_number": device_status.get("about", {}).get(
-                            "serial_number"
-                        ),
-                    },
-                )
-            except SleepMeAuthError:
-                errors["base"] = "invalid_token"
-            except (SleepMeRateLimited, SleepMeConnectionError):
-                errors["base"] = "cannot_connect"
-            except Exception:
-                _LOGGER.exception("Error fetching device status")
-                errors["base"] = "cannot_fetch_device_info"
+                try:
+                    device_status = await client.get_device_status()
+                    return self.async_create_entry(
+                        title=f"Dock Pro {name}",
+                        data={
+                            "api_token": self.api_token,
+                            "device_id": device_id,
+                            "firmware_version": device_status.get("about", {}).get(
+                                "firmware_version"
+                            ),
+                            "mac_address": device_status.get("about", {}).get(
+                                "mac_address"
+                            ),
+                            "model": device_status.get("about", {}).get("model"),
+                            "serial_number": device_status.get("about", {}).get(
+                                "serial_number"
+                            ),
+                        },
+                    )
+                except SleepMeAuthError:
+                    errors["base"] = "invalid_token"
+                except (SleepMeRateLimited, SleepMeConnectionError):
+                    errors["base"] = "cannot_connect"
+                except Exception:
+                    _LOGGER.exception("Error fetching device status")
+                    errors["base"] = "cannot_fetch_device_info"
 
         if self.claimed_devices:
             self._claimed_devices_dict = {

--- a/custom_components/sleepme_thermostat/const.py
+++ b/custom_components/sleepme_thermostat/const.py
@@ -14,6 +14,14 @@ PRESET_TEMPERATURES = {PRESET_MAX_COOL: -1, PRESET_MAX_HEAT: 999}
 MIN_TEMP_C = 13.0
 MAX_TEMP_C = 48.0
 
+# Device-ID prefixes the v1 API cannot serve. Gen-2 / Chilipad 2.0 units use
+# "x2-" IDs that v1 GET/PATCH /devices/{id} rejects with HTTP 400
+# "invalid device ID", while the v2 device surface returns 403 for developer
+# tokens. The integration can enumerate these devices via GET /devices but can
+# neither read their status nor control them, so the config flow blocks them
+# with a clear message. See https://github.com/rsampayo/sleepme_thermostat/issues/46.
+UNSUPPORTED_DEVICE_ID_PREFIXES = ("x2-",)
+
 # Options flow
 CONF_SCAN_INTERVAL = "scan_interval"
 # 30s default keeps 3-device installs comfortably under the 9 req/min

--- a/custom_components/sleepme_thermostat/manifest.json
+++ b/custom_components/sleepme_thermostat/manifest.json
@@ -11,5 +11,5 @@
   "loggers": ["custom_components.sleepme_thermostat"],
   "quality_scale": "silver",
   "requirements": [],
-  "version": "4.1.1"
+  "version": "4.1.2"
 }

--- a/custom_components/sleepme_thermostat/strings.json
+++ b/custom_components/sleepme_thermostat/strings.json
@@ -38,7 +38,8 @@
       "cannot_connect": "Failed to connect to the SleepMe API.",
       "no_devices_found": "No devices found for this API token.",
       "cannot_fetch_device_info": "Unable to fetch device information.",
-      "device_not_found_for_token": "This token does not have access to the originally configured device."
+      "device_not_found_for_token": "This token does not have access to the originally configured device.",
+      "unsupported_gen2_device": "Gen-2 / Chilipad 2.0 devices aren't supported yet. The SleepMe developer API rejects these units, so Home Assistant can't read or control them. Track progress at github.com/rsampayo/sleepme_thermostat/issues/46."
     },
     "abort": {
       "already_configured": "This device is already configured.",

--- a/custom_components/sleepme_thermostat/translations/en.json
+++ b/custom_components/sleepme_thermostat/translations/en.json
@@ -38,7 +38,8 @@
       "cannot_connect": "Failed to connect to the SleepMe API.",
       "no_devices_found": "No devices found for this API token.",
       "cannot_fetch_device_info": "Unable to fetch device information.",
-      "device_not_found_for_token": "This token does not have access to the originally configured device."
+      "device_not_found_for_token": "This token does not have access to the originally configured device.",
+      "unsupported_gen2_device": "Gen-2 / Chilipad 2.0 devices aren't supported yet. The SleepMe developer API rejects these units, so Home Assistant can't read or control them. Track progress at github.com/rsampayo/sleepme_thermostat/issues/46."
     },
     "abort": {
       "already_configured": "This device is already configured.",

--- a/custom_components/sleepme_thermostat/translations/es.json
+++ b/custom_components/sleepme_thermostat/translations/es.json
@@ -38,7 +38,8 @@
       "cannot_connect": "No se pudo conectar a la API. Por favor, verifique el token e intente nuevamente.",
       "no_devices_found": "No se encontraron dispositivos con el token proporcionado.",
       "cannot_fetch_device_info": "No se puede obtener la información del dispositivo. Por favor, verifique su conexión e intente nuevamente.",
-      "device_not_found_for_token": "Este token no tiene acceso al dispositivo configurado originalmente."
+      "device_not_found_for_token": "Este token no tiene acceso al dispositivo configurado originalmente.",
+      "unsupported_gen2_device": "Los dispositivos Gen-2 / Chilipad 2.0 aún no son compatibles. La API de desarrollador de SleepMe rechaza estas unidades, por lo que Home Assistant no puede leerlas ni controlarlas. Sigue el progreso en github.com/rsampayo/sleepme_thermostat/issues/46."
     },
     "abort": {
       "already_configured": "Este dispositivo ya está configurado.",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -70,6 +70,33 @@ async def test_happy_path(hass: HomeAssistant, mock_flow_client: AsyncMock) -> N
     assert result["data"]["model"] == "Dock Pro"
 
 
+async def test_select_device_rejects_gen2(
+    hass: HomeAssistant, mock_flow_client: AsyncMock
+) -> None:
+    """Gen-2 ('x2-') devices are blocked with a clear error, no API call made."""
+    gen2_id = "x2-d8fe1o7aq7uc73jgee8g"
+    mock_flow_client.get_claimed_devices.return_value = [
+        {"id": gen2_id, "name": "Chilipad 2.0"}
+    ]
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"api_token": MOCK_API_TOKEN}
+    )
+    assert result["step_id"] == "select_device"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"device_id": gen2_id}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "select_device"
+    assert result["errors"] == {"base": "unsupported_gen2_device"}
+    # Unsupported devices must be blocked before any per-device API call.
+    mock_flow_client.get_device_status.assert_not_called()
+
+
 async def test_user_step_invalid_token(
     hass: HomeAssistant, mock_flow_client: AsyncMock
 ) -> None:


### PR DESCRIPTION
## What

Gracefully handle gen-2 / Chilipad 2.0 devices in the config flow instead of failing with a generic error.

## Why

Gen-2 units enumerate fine via `GET /v1/devices` (they come back with `x2-…` IDs), but the sleep.me API can't serve them to developer tokens:

- `GET /v1/devices/x2-…` → **400** `{"message":"invalid device ID x2-…"}`
- `GET /v2/devices` (valid developer token) → **403** `ForbiddenException`

Verified against the live API on 2026-06-16. A **control test** confirms it's a *format* rejection, not an unknown-device case: a well-formed but nonexistent `zx-…` ID returns **404 not found**, while an `x2-…` ID returns **400**. So the v1 `:device_id` validator's prefix allowlist accepts `zx-`/`st-` but not `x2-`.

Previously, selecting a gen-2 device in the picker fell through to the generic `cannot_fetch_device_info` error. Now the user gets a clear, actionable message and we skip the doomed API call.

Tracked upstream with SleepMe in #46.

## Changes

- `const.py`: `UNSUPPORTED_DEVICE_ID_PREFIXES = ("x2-",)`
- `config_flow.py`: detect the prefix at device selection → `unsupported_gen2_device` error (no API call)
- `strings.json` + `translations/en.json` + `translations/es.json`: new message (EN + ES)
- `tests/test_config_flow.py`: `test_select_device_rejects_gen2` (asserts error **and** `get_device_status` not called)
- `manifest.json`: 4.1.1 → 4.1.2

## Test steps

- `pytest --cov` → 60 passed, 89.50% coverage (gate 80%)
- `ruff check` clean · `ruff format --check` clean · `mypy --strict` clean
- strings.json ≡ translations/en.json (i18n mirror)

Refs #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject unsupported Gen-2/Chilipad 2.0 devices during setup with a clear error message, preventing failed configuration attempts.

* **Documentation**
  * Enhanced error messages for unsupported devices with guidance and references to known issues.

* **Chores**
  * Version bumped to 4.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->