### PR TITLE
Add gen-2 (Chilipad 2.0) support now that v1 API serves x2- devices

### DIFF
--- a/custom_components/sleepme_thermostat/climate.py
+++ b/custom_components/sleepme_thermostat/climate.py
@@ -126,7 +126,13 @@ class SleepMeThermostat(CoordinatorEntity, ClimateEntity):
 
     @property
     def current_temperature(self) -> float | None:
-        return self.coordinator.data["status"].get("water_temperature_c")
+        water_temp_c = self.coordinator.data["status"].get("water_temperature_c")
+        # Gen-2 / Chilipad 2.0 units report -1 for water_temperature_c (and _f)
+        # while idle in standby — a "no reading" sentinel, not a real
+        # sub-zero water bath. Surface it as unknown rather than -1 C.
+        if water_temp_c is not None and water_temp_c < 0:
+            return None
+        return water_temp_c
 
     @property
     def target_temperature(self) -> float | None:

--- a/custom_components/sleepme_thermostat/config_flow.py
+++ b/custom_components/sleepme_thermostat/config_flow.py
@@ -18,7 +18,6 @@ from .const import (
     DOMAIN,
     MAX_SCAN_INTERVAL,
     MIN_SCAN_INTERVAL,
-    UNSUPPORTED_DEVICE_ID_PREFIXES,
 )
 from .sleepme import SleepMeClient
 from .sleepme_api import (
@@ -100,45 +99,37 @@ class SleepMeThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             device_id = user_input["device_id"]
             name = self._claimed_devices_dict[device_id]
 
-            if device_id.startswith(UNSUPPORTED_DEVICE_ID_PREFIXES):
-                # Gen-2 / Chilipad 2.0 ("x2-") devices: the sleep.me v1 API
-                # rejects these IDs with HTTP 400 and the v2 surface returns 403
-                # for developer tokens, so we can read neither status nor control
-                # them yet. Block with a clear message instead of a generic
-                # fetch error. See issue #46.
-                errors["base"] = "unsupported_gen2_device"
-            else:
-                await self.async_set_unique_id(device_id)
-                self._abort_if_unique_id_configured()
+            await self.async_set_unique_id(device_id)
+            self._abort_if_unique_id_configured()
 
-                client = SleepMeClient(self.hass, API_URL, self.api_token, device_id)
+            client = SleepMeClient(self.hass, API_URL, self.api_token, device_id)
 
-                try:
-                    device_status = await client.get_device_status()
-                    return self.async_create_entry(
-                        title=f"Dock Pro {name}",
-                        data={
-                            "api_token": self.api_token,
-                            "device_id": device_id,
-                            "firmware_version": device_status.get("about", {}).get(
-                                "firmware_version"
-                            ),
-                            "mac_address": device_status.get("about", {}).get(
-                                "mac_address"
-                            ),
-                            "model": device_status.get("about", {}).get("model"),
-                            "serial_number": device_status.get("about", {}).get(
-                                "serial_number"
-                            ),
-                        },
-                    )
-                except SleepMeAuthError:
-                    errors["base"] = "invalid_token"
-                except (SleepMeRateLimited, SleepMeConnectionError):
-                    errors["base"] = "cannot_connect"
-                except Exception:
-                    _LOGGER.exception("Error fetching device status")
-                    errors["base"] = "cannot_fetch_device_info"
+            try:
+                device_status = await client.get_device_status()
+                return self.async_create_entry(
+                    title=f"Dock Pro {name}",
+                    data={
+                        "api_token": self.api_token,
+                        "device_id": device_id,
+                        "firmware_version": device_status.get("about", {}).get(
+                            "firmware_version"
+                        ),
+                        "mac_address": device_status.get("about", {}).get(
+                            "mac_address"
+                        ),
+                        "model": device_status.get("about", {}).get("model"),
+                        "serial_number": device_status.get("about", {}).get(
+                            "serial_number"
+                        ),
+                    },
+                )
+            except SleepMeAuthError:
+                errors["base"] = "invalid_token"
+            except (SleepMeRateLimited, SleepMeConnectionError):
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Error fetching device status")
+                errors["base"] = "cannot_fetch_device_info"
 
         if self.claimed_devices:
             self._claimed_devices_dict = {

--- a/custom_components/sleepme_thermostat/const.py
+++ b/custom_components/sleepme_thermostat/const.py
@@ -14,14 +14,6 @@ PRESET_TEMPERATURES = {PRESET_MAX_COOL: -1, PRESET_MAX_HEAT: 999}
 MIN_TEMP_C = 13.0
 MAX_TEMP_C = 48.0
 
-# Device-ID prefixes the v1 API cannot serve. Gen-2 / Chilipad 2.0 units use
-# "x2-" IDs that v1 GET/PATCH /devices/{id} rejects with HTTP 400
-# "invalid device ID", while the v2 device surface returns 403 for developer
-# tokens. The integration can enumerate these devices via GET /devices but can
-# neither read their status nor control them, so the config flow blocks them
-# with a clear message. See https://github.com/rsampayo/sleepme_thermostat/issues/46.
-UNSUPPORTED_DEVICE_ID_PREFIXES = ("x2-",)
-
 # Options flow
 CONF_SCAN_INTERVAL = "scan_interval"
 # 30s default keeps 3-device installs comfortably under the 9 req/min

--- a/custom_components/sleepme_thermostat/manifest.json
+++ b/custom_components/sleepme_thermostat/manifest.json
@@ -11,5 +11,5 @@
   "loggers": ["custom_components.sleepme_thermostat"],
   "quality_scale": "silver",
   "requirements": [],
-  "version": "4.1.2"
+  "version": "4.2.0"
 }

--- a/custom_components/sleepme_thermostat/strings.json
+++ b/custom_components/sleepme_thermostat/strings.json
@@ -38,8 +38,7 @@
       "cannot_connect": "Failed to connect to the SleepMe API.",
       "no_devices_found": "No devices found for this API token.",
       "cannot_fetch_device_info": "Unable to fetch device information.",
-      "device_not_found_for_token": "This token does not have access to the originally configured device.",
-      "unsupported_gen2_device": "Gen-2 / Chilipad 2.0 devices aren't supported yet. The SleepMe developer API rejects these units, so Home Assistant can't read or control them. Track progress at github.com/rsampayo/sleepme_thermostat/issues/46."
+      "device_not_found_for_token": "This token does not have access to the originally configured device."
     },
     "abort": {
       "already_configured": "This device is already configured.",

--- a/custom_components/sleepme_thermostat/translations/en.json
+++ b/custom_components/sleepme_thermostat/translations/en.json
@@ -38,8 +38,7 @@
       "cannot_connect": "Failed to connect to the SleepMe API.",
       "no_devices_found": "No devices found for this API token.",
       "cannot_fetch_device_info": "Unable to fetch device information.",
-      "device_not_found_for_token": "This token does not have access to the originally configured device.",
-      "unsupported_gen2_device": "Gen-2 / Chilipad 2.0 devices aren't supported yet. The SleepMe developer API rejects these units, so Home Assistant can't read or control them. Track progress at github.com/rsampayo/sleepme_thermostat/issues/46."
+      "device_not_found_for_token": "This token does not have access to the originally configured device."
     },
     "abort": {
       "already_configured": "This device is already configured.",

--- a/custom_components/sleepme_thermostat/translations/es.json
+++ b/custom_components/sleepme_thermostat/translations/es.json
@@ -38,8 +38,7 @@
       "cannot_connect": "No se pudo conectar a la API. Por favor, verifique el token e intente nuevamente.",
       "no_devices_found": "No se encontraron dispositivos con el token proporcionado.",
       "cannot_fetch_device_info": "No se puede obtener la información del dispositivo. Por favor, verifique su conexión e intente nuevamente.",
-      "device_not_found_for_token": "Este token no tiene acceso al dispositivo configurado originalmente.",
-      "unsupported_gen2_device": "Los dispositivos Gen-2 / Chilipad 2.0 aún no son compatibles. La API de desarrollador de SleepMe rechaza estas unidades, por lo que Home Assistant no puede leerlas ni controlarlas. Sigue el progreso en github.com/rsampayo/sleepme_thermostat/issues/46."
+      "device_not_found_for_token": "Este token no tiene acceso al dispositivo configurado originalmente."
     },
     "abort": {
       "already_configured": "Este dispositivo ya está configurado.",

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -289,6 +289,20 @@ async def test_current_temperature_passthrough(
     assert state.attributes["current_temperature"] == 22.0
 
 
+async def test_current_temperature_negative_sentinel_is_unknown(
+    hass: HomeAssistant, mock_sleepme_client: AsyncMock
+) -> None:
+    """Gen-2 units report water_temperature_c == -1 in standby; surface it as
+    unknown rather than a bogus sub-zero reading. See issue #46."""
+    entry = await _setup(hass)
+    coord = entry.runtime_data.coordinator
+    coord.data["status"]["water_temperature_c"] = -1
+    coord.async_update_listeners()
+    await hass.async_block_till_done()
+    state = hass.states.get(ENTITY_ID)
+    assert state.attributes["current_temperature"] is None
+
+
 async def test_available_false_when_coordinator_unsuccessful(
     hass: HomeAssistant, mock_sleepme_client: AsyncMock
 ) -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -70,14 +70,23 @@ async def test_happy_path(hass: HomeAssistant, mock_flow_client: AsyncMock) -> N
     assert result["data"]["model"] == "Dock Pro"
 
 
-async def test_select_device_rejects_gen2(
+async def test_select_device_accepts_gen2(
     hass: HomeAssistant, mock_flow_client: AsyncMock
 ) -> None:
-    """Gen-2 ('x2-') devices are blocked with a clear error, no API call made."""
+    """Gen-2 ('x2-') devices now configure like any other once the v1 API
+    serves them. See issue #46."""
     gen2_id = "x2-d8fe1o7aq7uc73jgee8g"
     mock_flow_client.get_claimed_devices.return_value = [
         {"id": gen2_id, "name": "Chilipad 2.0"}
     ]
+    mock_flow_client.get_device_status.return_value = {
+        "about": {
+            "firmware_version": "1.11.1339",
+            "mac_address": "ee:ee:ee:ee:ee:ee",
+            "model": "DP723NA",
+            "serial_number": "12345600290",
+        }
+    }
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -90,11 +99,11 @@ async def test_select_device_rejects_gen2(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"device_id": gen2_id}
     )
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "select_device"
-    assert result["errors"] == {"base": "unsupported_gen2_device"}
-    # Unsupported devices must be blocked before any per-device API call.
-    mock_flow_client.get_device_status.assert_not_called()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Dock Pro Chilipad 2.0"
+    assert result["data"]["device_id"] == gen2_id
+    assert result["data"]["model"] == "DP723NA"
+    mock_flow_client.get_device_status.assert_called_once()
 
 
 async def test_user_step_invalid_token(


### PR DESCRIPTION
## Summary

Gen-2 / Chilipad 2.0 units use `x2-` device IDs. The sleep.me v1 API used to reject these with HTTP 400 (`invalid device ID`), and the v2 surface returns 403 for developer tokens, so #47 added a config-flow guard that blocked them with a clear message.

Per the latest report on #46, the backend now serves gen-2 devices: `GET /v1/devices/x2-...` returns the full `about/control/status` payload, identical in shape to gen-1. This PR lifts the guard so gen-2 hardware configures through the normal path.

## Changes

- `config_flow.py`: remove the `x2-` rejection; gen-2 devices go through `get_device_status` like any other unit.
- `const.py`: drop the now-unused `UNSUPPORTED_DEVICE_ID_PREFIXES`.
- `strings.json` / `translations/{en,es}.json`: remove the `unsupported_gen2_device` error string.
- `climate.py`: map the gen-2 standby sentinel `water_temperature_c == -1` to `None` so HA shows "unknown" instead of a bogus sub-zero current temperature.
- `manifest.json`: 4.1.2 -> 4.2.0.

## Tests

- Replaced the gen-2 *rejection* test with a gen-2 *acceptance* test using the real `x2-`/`DP723NA` sample from #46.
- Added a regression test for the `-1` water-temperature sentinel.
- Full suite: 61 passed, 89.50% coverage. ruff, ruff format, and mypy clean.

Closes #46. Follows up #47.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gen-2 devices can now be added during setup.
* **Bug Fixes**
  * A standby temperature reading is now shown as unknown instead of `-1°C`.
  * Setup error handling was simplified to focus on connection, token, and device-info issues.
* **Chores**
  * Updated the integration version to `4.2.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->