### PR TITLE
Add Sleep Tracker and sleep report support

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Import any blueprint in *Settings → Automations & Scenes → Blueprints → Im
 
 These are deterministic HA rules, not a clone of Sleepme's proprietary Hiber-AI model. A stock-card dashboard example is available at [docs/examples/sleep_tracker_dashboard.yaml](docs/examples/sleep_tracker_dashboard.yaml).
 
-All HA-supported frontend languages can load and use the integration. Entity and option text uses HA's translation system; Spanish is included and every other locale receives HA's built-in English fallback instead of broken or missing labels.
+All HA-supported frontend languages can load and use the integration. Entity and option text uses HA's translation system; Spanish and complete native Hungarian translations are included, while every remaining locale receives HA's built-in English fallback instead of broken or missing labels.
 
 ## Troubleshooting
 
@@ -183,7 +183,7 @@ Older HA versions may work but are not in the CI matrix.
 
 Contributions are welcome! Please open an issue or submit a pull request.
 
-When editing translations, edit `custom_components/sleepme_thermostat/strings.json` first (the source of truth), then copy verbatim to `custom_components/sleepme_thermostat/translations/en.json`. CI fails if the two files diverge. Other language files (e.g. `es.json`) are hand-maintained from `strings.json`.
+When editing translations, edit `custom_components/sleepme_thermostat/strings.json` first (the source of truth), then copy verbatim to `custom_components/sleepme_thermostat/translations/en.json`. CI fails if the two files diverge. Other language files (such as `es.json` and `hu.json`) are hand-maintained from `strings.json`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,14 @@
 - Real-time bed occupancy, connectivity, bed temperature, room temperature, and humidity.
 - Latest completed daily sleep report with score, session count, bed-entry/exit times, sleep latency, and total/in-bed/asleep/awake/light/REM/deep durations.
 - Multiple sessions (for example, naps plus overnight sleep) are aggregated into daily sensors.
-- Hypnogram segment count as a sensor.
+- Derived sleep efficiency, wake after sleep onset, stage percentages, restorative sleep, awakenings, longest uninterrupted sleep, main-session timing, sleep midpoint, and additional-session metrics.
+- Configurable sleep goal with nightly goal percentage, sleep debt, and cumulative 7/30-day debt.
+- Seven- and thirty-day averages plus bedtime/wake-time consistency.
+- Four ready-to-import automation blueprints for occupancy actions, presence-aware Dock control, return-to-bed temperature adjustment, and sleep-report alerts.
 - A response-only `sleepme_thermostat.get_sleep_reports` action returns the lossless raw reports, including session IDs and every hypnogram segment, without storing that large health payload in Home Assistant's recorder.
-- Sleep reports use a separate 30-minute polling cadence to protect the API request budget.
+- Sleep reports page over 30 days at a separate 30-minute polling cadence to protect the API request budget.
+
+See [Sleep Tracker features, formulas, and limitations](docs/sleep-tracker.md) for the exact direct-versus-derived boundary. In particular, the public API does not currently expose biometrics or live sleep stages, so HA cannot reproduce those consumer-app features honestly.
 
 ## Requirements
 
@@ -69,7 +74,7 @@
 2. *Settings → Devices & Services → Add Integration → SleepMe*.
 3. Paste the token; pick the Chilipad or Sleep Tracker from the discovered list.
 
-To tune the polling cadence: *Settings → Devices & Services → SleepMe → Configure → Poll interval*.
+To tune the polling cadence: *Settings → Devices & Services → SleepMe → Configure → Poll interval*. Sleep Tracker entries also expose a 4–12 hour personal sleep target used only by HA's goal/debt calculations.
 
 ## Entities created
 
@@ -103,6 +108,16 @@ To tune the polling cadence: *Settings → Devices & Services → SleepMe → Co
 | sensor | Awake / Light / REM / Deep Sleep Duration | Daily stage totals in seconds |
 | sensor | Sleep Latency | Sum across the day's sessions, in seconds |
 | sensor | Hypnogram Segments | Total raw segment count |
+| sensor | Sleep Efficiency / Wake After Sleep Onset | Derived from public duration fields |
+| sensor | Awake / Light / REM / Deep / Restorative Percentage | Derived daily composition |
+| sensor | Restorative Sleep / Longest Uninterrupted Sleep | Derived durations |
+| sensor | Sleep Goal / Sleep Debt | Based on the configurable HA target |
+| sensor | Awakenings | Sleep-to-awake hypnogram transitions |
+| sensor | Main Sleep Entered/Exited Bed / Sleep Midpoint | Longest session is treated as main sleep |
+| sensor | Additional Sleep Sessions / Duration | All sessions other than the longest |
+| sensor | 7-day and 30-day averages | Score, duration, efficiency, latency, stages, awakenings |
+| sensor | 7-day and 30-day consistency | Mean clock-time deviation for bedtime and wake time |
+| sensor | 7-day and 30-day cumulative debt | Sum of per-night debt in the window |
 | sensor | IP / LAN / Firmware | Diagnostic |
 
 ## Fetch complete raw sleep reports
@@ -121,26 +136,20 @@ response_variable: sleepme_data
 
 The normal sensors intentionally keep hypnogram arrays out of state attributes so Home Assistant's recorder does not duplicate a large health-data payload every refresh. Sleepme's consumer app documents heart rate, HRV, and respiration, but the current public `/sleep-reports` response does not expose those fields; this integration cannot create values that the public API does not return.
 
-## Example automation: cool the bed at bedtime
+## Automation blueprints
 
-```yaml
-automation:
-  - alias: SleepMe — cool bed at bedtime
-    trigger:
-      - platform: time
-        at: "22:30:00"
-    action:
-      - service: climate.set_hvac_mode
-        target:
-          entity_id: climate.dock_pro_ramon
-        data:
-          hvac_mode: auto
-      - service: climate.set_temperature
-        target:
-          entity_id: climate.dock_pro_ramon
-        data:
-          temperature: 18
-```
+Import any blueprint in *Settings → Automations & Scenes → Blueprints → Import Blueprint* using its raw URL:
+
+| Blueprint | What it reproduces with HA data |
+|---|---|
+| [Occupancy actions](blueprints/automation/sleepme_thermostat/tracker_occupancy_actions.yaml) | Run lights, scenes, locks, or notifications when bed occupancy changes |
+| [Presence-aware Dock control](blueprints/automation/sleepme_thermostat/dock_presence_control.yaml) | Early/late bedtime, scheduled start, early wake, and snooze-safe shutdown |
+| [Return-to-bed adjustment](blueprints/automation/sleepme_thermostat/dock_back_to_sleep.yaml) | Temporary configurable Dock adjustment after an overnight absence and return |
+| [Sleep report alert](blueprints/automation/sleepme_thermostat/sleep_report_alert.yaml) | Notify on transparent score, duration, efficiency, latency, and deep-sleep thresholds |
+
+These are deterministic HA rules, not a clone of Sleepme's proprietary Hiber-AI model. A stock-card dashboard example is available at [docs/examples/sleep_tracker_dashboard.yaml](docs/examples/sleep_tracker_dashboard.yaml).
+
+All HA-supported frontend languages can load and use the integration. Entity and option text uses HA's translation system; Spanish is included and every other locale receives HA's built-in English fallback instead of broken or missing labels.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SleepMe Dock Pro Integration
+# SleepMe Integration
 
 [![HACS Custom Repository](https://img.shields.io/badge/HACS-Custom_Repository-41BDF5.svg)](https://github.com/hacs/default)
 [![Quality Scale](https://img.shields.io/badge/Quality_Scale-silver-c0c0c0.svg)](https://www.home-assistant.io/docs/quality_scale/)
@@ -8,9 +8,19 @@
 [![CodeQL](https://github.com/rsampayo/sleepme_thermostat/actions/workflows/codeql.yml/badge.svg)](https://github.com/rsampayo/sleepme_thermostat/actions/workflows/codeql.yml)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-> A Home Assistant custom integration for the **SleepMe Chilipad Dock Pro** bed-cooling system. Climate entity, water-level alert, connectivity sensor, and five diagnostic sensors — all backed by the [sleep.me developer API](https://docs.developer.sleep.me/api/).
+> A Home Assistant custom integration for **SleepMe Chilipad climate systems and the ST501NA Sleep Tracker**, backed by the [sleep.me developer API](https://docs.developer.sleep.me/api/).
+
+## Supported devices
+
+| Model | Product | Support |
+|---|---|---|
+| DP999NA | Chilipad Dock Pro | Climate control and complete live device status |
+| DP723NA / `x2-…` devices | Chilipad 2.0 | Climate control and complete live device status |
+| ST501NA | Sleepme Sleep Tracker | Live occupancy/environment data and complete public-API sleep reports |
 
 ## Features
+
+### Chilipad climate systems
 
 - Set bed temperature (13–48°C, half-degree steps, plus `Max Cool` / `Max Heat` presets per API contract).
 - Turn the device on/off via HVAC mode.
@@ -22,10 +32,19 @@
 - Multi-device support: configure multiple Dock Pros under one HA install.
 - Long-term statistics for brightness.
 
+### ST501NA Sleep Tracker
+
+- Real-time bed occupancy, connectivity, bed temperature, room temperature, and humidity.
+- Latest completed daily sleep report with score, session count, bed-entry/exit times, sleep latency, and total/in-bed/asleep/awake/light/REM/deep durations.
+- Multiple sessions (for example, naps plus overnight sleep) are aggregated into daily sensors.
+- Hypnogram segment count as a sensor.
+- A response-only `sleepme_thermostat.get_sleep_reports` action returns the lossless raw reports, including session IDs and every hypnogram segment, without storing that large health payload in Home Assistant's recorder.
+- Sleep reports use a separate 30-minute polling cadence to protect the API request budget.
+
 ## Requirements
 
 - Home Assistant Core **2026.1** or newer (tested on 2026.1, 2026.3, 2026.5).
-- A sleep.me account with at least one Dock Pro device.
+- A sleep.me account with at least one supported Chilipad or Sleep Tracker device.
 - A developer API token (generated in the sleep.me account portal, free).
 
 ## Installation
@@ -33,9 +52,9 @@
 ### HACS (recommended)
 
 1. HACS → ⋮ → *Custom repositories* → add `https://github.com/rsampayo/sleepme_thermostat`, category *Integration*.
-2. Install **SleepMe Thermostat**.
+2. Install **SleepMe**.
 3. Restart Home Assistant.
-4. *Settings → Devices & Services → Add Integration → SleepMe Thermostat*.
+4. *Settings → Devices & Services → Add Integration → SleepMe*.
 
 ### Manual
 
@@ -47,12 +66,14 @@
 ## Configuration
 
 1. Generate an API token: sleep.me website → account → *Developer API* → *Create new token*.
-2. *Settings → Devices & Services → Add Integration → SleepMe Thermostat*.
-3. Paste the token; pick the device from the discovered list.
+2. *Settings → Devices & Services → Add Integration → SleepMe*.
+3. Paste the token; pick the Chilipad or Sleep Tracker from the discovered list.
 
-To tune the polling cadence: *Settings → Devices & Services → SleepMe Thermostat → Configure → Poll interval*.
+To tune the polling cadence: *Settings → Devices & Services → SleepMe → Configure → Poll interval*.
 
 ## Entities created
+
+### Chilipad climate systems
 
 | Platform       | Entity                       | Notes                              |
 |----------------|------------------------------|------------------------------------|
@@ -64,6 +85,41 @@ To tune the polling cadence: *Settings → Devices & Services → SleepMe Thermo
 | sensor         | Brightness Level (%)         | Diagnostic, in long-term statistics |
 | sensor         | Display Temperature Unit     | Diagnostic                         |
 | sensor         | Time Zone                    | Diagnostic                         |
+
+### ST501NA Sleep Tracker
+
+| Platform | Entity | Notes |
+|---|---|---|
+| binary_sensor | Bed Occupancy | Live `user_detected`; device class: OCCUPANCY |
+| binary_sensor | Connected | Device class: CONNECTIVITY |
+| sensor | Environment Humidity | Live percentage |
+| sensor | Environment Temperature | Live room temperature |
+| sensor | Bed Temperature | Live in-bed temperature |
+| sensor | Last Sleep Report | Date of the latest completed report |
+| sensor | Sleep Score | Percentage |
+| sensor | Sleep Sessions | Sessions aggregated into the report |
+| sensor | Entered Bed / Exited Bed | Earliest entry and latest exit timestamps |
+| sensor | Total Session / In-bed / Total Sleep Duration | Daily totals in seconds |
+| sensor | Awake / Light / REM / Deep Sleep Duration | Daily stage totals in seconds |
+| sensor | Sleep Latency | Sum across the day's sessions, in seconds |
+| sensor | Hypnogram Segments | Total raw segment count |
+| sensor | IP / LAN / Firmware | Diagnostic |
+
+## Fetch complete raw sleep reports
+
+The public API returns up to seven days per request. Use the response-only action when an automation needs the complete session and hypnogram payload:
+
+```yaml
+action: sleepme_thermostat.get_sleep_reports
+data:
+  config_entry_id: 01JEXAMPLECONFIGENTRY
+  start_date: "2026-07-13"
+  days_back: 6
+  time_zone: Europe/Budapest
+response_variable: sleepme_data
+```
+
+The normal sensors intentionally keep hypnogram arrays out of state attributes so Home Assistant's recorder does not duplicate a large health-data payload every refresh. Sleepme's consumer app documents heart rate, HRV, and respiration, but the current public `/sleep-reports` response does not expose those fields; this integration cannot create values that the public API does not return.
 
 ## Example automation: cool the bed at bedtime
 
@@ -95,7 +151,7 @@ Tokens can be rotated or revoked in the sleep.me developer portal. When that hap
 The sleep.me API is aggressively rate-limited. Transient failures are normal — the integration honors `Retry-After` and recovers on the next poll. If the entity stays unavailable for more than a few minutes, check the log under `custom_components.sleepme_thermostat`.
 
 **Polling too aggressive / not aggressive enough.**
-The default poll interval is **20 seconds**. To change it: *Settings → Devices & Services → SleepMe Thermostat → Configure*. Acceptable range 10–300 s. Lower values feel snappier but consume more of your per-minute API budget.
+The default live-device poll interval is **30 seconds**. To change it: *Settings → Devices & Services → SleepMe → Configure*. Acceptable range 10–300 s. Lower values feel snappier but consume more of your per-minute API budget. Tracker sleep reports always use a separate 30-minute interval.
 
 **Sharing a bug report.**
 Open the device page in *Settings → Devices & Services*, click ⋮, choose *Download diagnostics*. The downloaded JSON has your API token (and MAC, IP, serial) redacted. Attach it to a GitHub issue.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 - Derived sleep efficiency, wake after sleep onset, stage percentages, restorative sleep, awakenings, longest uninterrupted sleep, main-session timing, sleep midpoint, and additional-session metrics.
 - Configurable sleep goal with nightly goal percentage, sleep debt, and cumulative 7/30-day debt.
 - Seven- and thirty-day averages plus bedtime/wake-time consistency.
-- Four ready-to-import automation blueprints for occupancy actions, presence-aware Dock control, return-to-bed temperature adjustment, and sleep-report alerts.
+- Five ready-to-import automation blueprints for occupancy actions, presence-aware Dock control with an occupied wake-time extension, return-to-bed temperature adjustment, Warm Awake, and sleep-report alerts.
 - A response-only `sleepme_thermostat.get_sleep_reports` action returns the lossless raw reports, including session IDs and every hypnogram segment, without storing that large health payload in Home Assistant's recorder.
 - Sleep reports page over 30 days at a separate 30-minute polling cadence to protect the API request budget.
 
@@ -134,7 +134,7 @@ data:
 response_variable: sleepme_data
 ```
 
-The normal sensors intentionally keep hypnogram arrays out of state attributes so Home Assistant's recorder does not duplicate a large health-data payload every refresh. Sleepme's consumer app documents heart rate, HRV, and respiration, but the current public `/sleep-reports` response does not expose those fields; this integration cannot create values that the public API does not return.
+The raw API expresses report durations and hypnogram offsets in minutes. Sensor entities normalize them to seconds for Home Assistant's duration device class; the response-only action deliberately preserves the raw minute values. Normal sensors intentionally keep hypnogram arrays out of state attributes so Home Assistant's recorder does not duplicate a large health-data payload every refresh. Sleepme's consumer app documents heart rate, HRV, and respiration, but the current public `/sleep-reports` response does not expose those fields; this integration cannot create values that the public API does not return.
 
 ## Automation blueprints
 
@@ -145,6 +145,7 @@ Import any blueprint in *Settings → Automations & Scenes → Blueprints → Im
 | [Occupancy actions](blueprints/automation/sleepme_thermostat/tracker_occupancy_actions.yaml) | Run lights, scenes, locks, or notifications when bed occupancy changes |
 | [Presence-aware Dock control](blueprints/automation/sleepme_thermostat/dock_presence_control.yaml) | Early/late bedtime, scheduled start, early wake, and snooze-safe shutdown |
 | [Return-to-bed adjustment](blueprints/automation/sleepme_thermostat/dock_back_to_sleep.yaml) | Temporary configurable Dock adjustment after an overnight absence and return |
+| [Warm-awake routine](blueprints/automation/sleepme_thermostat/tracker_warm_awake.yaml) | Warm an occupied bed before wake time for a configurable duration, then stop |
 | [Sleep report alert](blueprints/automation/sleepme_thermostat/sleep_report_alert.yaml) | Notify on transparent score, duration, efficiency, latency, and deep-sleep thresholds |
 
 These are deterministic HA rules, not a clone of Sleepme's proprietary Hiber-AI model. A stock-card dashboard example is available at [docs/examples/sleep_tracker_dashboard.yaml](docs/examples/sleep_tracker_dashboard.yaml).

--- a/blueprints/automation/sleepme_thermostat/dock_back_to_sleep.yaml
+++ b/blueprints/automation/sleepme_thermostat/dock_back_to_sleep.yaml
@@ -1,0 +1,127 @@
+blueprint:
+  name: SleepMe Tracker + Dock - Return-to-bed temperature adjustment
+  description: >-
+    When the sleeper leaves during the overnight window, wait for their return,
+    apply a temporary signed temperature adjustment, then restore the original
+    target. This is a transparent Home Assistant heuristic, not Sleepme Hiber-AI.
+  domain: automation
+  author: SleepMe Home Assistant integration
+  source_url: https://github.com/rsampayo/sleepme_thermostat/blob/main/blueprints/automation/sleepme_thermostat/dock_back_to_sleep.yaml
+  homeassistant:
+    min_version: 2026.1.0
+  input:
+    occupancy_sensor:
+      name: Tracker occupancy sensor
+      selector:
+        entity:
+          filter:
+            domain: binary_sensor
+    dock_climate:
+      name: Dock climate entity
+      selector:
+        entity:
+          filter:
+            domain: climate
+            integration: sleepme_thermostat
+    active_start_time:
+      name: Overnight window start
+      default: "20:00:00"
+      selector:
+        time:
+    active_end_time:
+      name: Overnight window end
+      default: "10:00:00"
+      selector:
+        time:
+    minimum_absence:
+      name: Minimum time out of bed
+      default:
+        seconds: 20
+      selector:
+        duration:
+    return_timeout:
+      name: Maximum time to wait for a return
+      default:
+        minutes: 30
+      selector:
+        duration:
+    temperature_adjustment:
+      name: Temporary temperature adjustment
+      description: Signed value in Home Assistant's temperature unit; negative is cooler.
+      default: -1
+      selector:
+        number:
+          min: -10
+          max: 10
+          step: 0.5
+          mode: box
+    adjustment_duration:
+      name: Adjustment duration
+      default:
+        minutes: 15
+      selector:
+        duration:
+
+mode: restart
+
+variables:
+  occupancy_entity: !input occupancy_sensor
+  dock_entity: !input dock_climate
+  configured_start: !input active_start_time
+  configured_end: !input active_end_time
+  adjustment: !input temperature_adjustment
+
+triggers:
+  - trigger: state
+    entity_id: !input occupancy_sensor
+    to: "off"
+    for: !input minimum_absence
+
+conditions:
+  - condition: template
+    value_template: >-
+      {% set start_parts = configured_start.split(':') %}
+      {% set end_parts = configured_end.split(':') %}
+      {% set start_minute = (start_parts[0] | int) * 60 + (start_parts[1] | int) %}
+      {% set end_minute = (end_parts[0] | int) * 60 + (end_parts[1] | int) %}
+      {% set current_minute = now().hour * 60 + now().minute %}
+      {{ (start_minute <= end_minute and
+          start_minute <= current_minute < end_minute) or
+         (start_minute > end_minute and
+          (current_minute >= start_minute or current_minute < end_minute)) }}
+  - condition: template
+    value_template: >-
+      {{ states(dock_entity) not in ['off', 'unknown', 'unavailable'] and
+         state_attr(dock_entity, 'temperature') is number }}
+
+actions:
+  - variables:
+      original_temperature: "{{ state_attr(dock_entity, 'temperature') | float }}"
+  - wait_for_trigger:
+      - trigger: state
+        entity_id: !input occupancy_sensor
+        to: "on"
+    timeout: !input return_timeout
+    continue_on_timeout: false
+  - condition: template
+    value_template: >-
+      {{ is_state(occupancy_entity, 'on') and
+         states(dock_entity) not in ['unknown', 'unavailable'] }}
+  - action: climate.set_hvac_mode
+    target:
+      entity_id: !input dock_climate
+    data:
+      hvac_mode: auto
+  - action: climate.set_temperature
+    target:
+      entity_id: !input dock_climate
+    data:
+      temperature: "{{ original_temperature + adjustment }}"
+  - delay: !input adjustment_duration
+  - condition: template
+    value_template: "{{ states(dock_entity) not in ['unknown', 'unavailable'] }}"
+  - action: climate.set_temperature
+    target:
+      entity_id: !input dock_climate
+    data:
+      temperature: "{{ original_temperature }}"

--- a/blueprints/automation/sleepme_thermostat/dock_back_to_sleep.yaml
+++ b/blueprints/automation/sleepme_thermostat/dock_back_to_sleep.yaml
@@ -47,8 +47,10 @@ blueprint:
         duration:
     temperature_adjustment:
       name: Temporary temperature adjustment
-      description: Signed value in Home Assistant's temperature unit; negative is cooler.
-      default: -1
+      description: >-
+        Signed value in Home Assistant's temperature unit. Sleepme documents a
+        +5 °F warming step (about +2.8 °C); adjust this to your comfort and unit.
+      default: 2.5
       selector:
         number:
           min: -10

--- a/blueprints/automation/sleepme_thermostat/dock_presence_control.yaml
+++ b/blueprints/automation/sleepme_thermostat/dock_presence_control.yaml
@@ -4,7 +4,8 @@ blueprint:
     Start a Dock when bed occupancy occurs within a configurable overnight
     window (including early bedtimes), start it at the scheduled time when the
     bed is already occupied, and stop it after the bed becomes empty or at the
-    scheduled end. Returning before the empty delay cancels the stop naturally.
+    scheduled end plus an optional occupied-bed extension. Returning before the
+    empty delay cancels the stop naturally.
   domain: automation
   author: SleepMe Home Assistant integration
   source_url: https://github.com/rsampayo/sleepme_thermostat/blob/main/blueprints/automation/sleepme_thermostat/dock_presence_control.yaml
@@ -63,6 +64,15 @@ blueprint:
         minutes: 5
       selector:
         duration:
+    occupied_wake_extension:
+      name: Extension when still in bed at wake time
+      description: >-
+        Keep the Dock running this much longer when the Tracker is occupied at
+        the scheduled end. Set to zero for a strict end time.
+      default:
+        minutes: 60
+      selector:
+        duration:
 
 mode: restart
 
@@ -93,8 +103,19 @@ triggers:
 
 actions:
   - choose:
-      - conditions: "{{ trigger.id in ['empty', 'scheduled_end'] }}"
+      - conditions: "{{ trigger.id == 'empty' }}"
         sequence:
+          - action: climate.turn_off
+            target:
+              entity_id: !input dock_climate
+      - conditions: "{{ trigger.id == 'scheduled_end' }}"
+        sequence:
+          - if:
+              - condition: state
+                entity_id: !input occupancy_sensor
+                state: "on"
+            then:
+              - delay: !input occupied_wake_extension
           - action: climate.turn_off
             target:
               entity_id: !input dock_climate

--- a/blueprints/automation/sleepme_thermostat/dock_presence_control.yaml
+++ b/blueprints/automation/sleepme_thermostat/dock_presence_control.yaml
@@ -1,0 +1,132 @@
+blueprint:
+  name: SleepMe Tracker + Dock - Presence-aware nightly control
+  description: >-
+    Start a Dock when bed occupancy occurs within a configurable overnight
+    window (including early bedtimes), start it at the scheduled time when the
+    bed is already occupied, and stop it after the bed becomes empty or at the
+    scheduled end. Returning before the empty delay cancels the stop naturally.
+  domain: automation
+  author: SleepMe Home Assistant integration
+  source_url: https://github.com/rsampayo/sleepme_thermostat/blob/main/blueprints/automation/sleepme_thermostat/dock_presence_control.yaml
+  homeassistant:
+    min_version: 2026.1.0
+  input:
+    occupancy_sensor:
+      name: Tracker occupancy sensor
+      description: Select the SleepMe Tracker User Detected binary sensor.
+      selector:
+        entity:
+          filter:
+            domain: binary_sensor
+    dock_climate:
+      name: Dock climate entity
+      selector:
+        entity:
+          filter:
+            domain: climate
+            integration: sleepme_thermostat
+    sleep_start_time:
+      name: Scheduled sleep start
+      default: "22:30:00"
+      selector:
+        time:
+    sleep_end_time:
+      name: Scheduled sleep end
+      default: "07:00:00"
+      selector:
+        time:
+    early_start_window:
+      name: Early-bed window
+      description: Minutes before the scheduled start during which occupancy starts the Dock.
+      default: 120
+      selector:
+        number:
+          min: 0
+          max: 360
+          step: 5
+          unit_of_measurement: min
+          mode: box
+    target_temperature:
+      name: Night target temperature
+      description: Enter this in Home Assistant's configured temperature unit.
+      default: 22
+      selector:
+        number:
+          min: 0
+          max: 120
+          step: 0.5
+          mode: box
+    empty_delay:
+      name: Stop after empty for
+      description: A return before this delay expires prevents a premature stop.
+      default:
+        minutes: 5
+      selector:
+        duration:
+
+mode: restart
+
+variables:
+  occupancy_entity: !input occupancy_sensor
+  dock_entity: !input dock_climate
+  configured_start: !input sleep_start_time
+  configured_end: !input sleep_end_time
+  early_minutes: !input early_start_window
+  night_temperature: !input target_temperature
+
+triggers:
+  - trigger: state
+    entity_id: !input occupancy_sensor
+    to: "on"
+    id: occupied
+  - trigger: state
+    entity_id: !input occupancy_sensor
+    to: "off"
+    for: !input empty_delay
+    id: empty
+  - trigger: time
+    at: !input sleep_start_time
+    id: scheduled_start
+  - trigger: time
+    at: !input sleep_end_time
+    id: scheduled_end
+
+actions:
+  - choose:
+      - conditions: "{{ trigger.id in ['empty', 'scheduled_end'] }}"
+        sequence:
+          - action: climate.turn_off
+            target:
+              entity_id: !input dock_climate
+      - conditions:
+          - condition: template
+            value_template: >-
+              {{ trigger.id == 'scheduled_start' or
+                 (trigger.id == 'occupied' and is_state(occupancy_entity, 'on')) }}
+          - condition: template
+            value_template: >-
+              {% set start_parts = configured_start.split(':') %}
+              {% set end_parts = configured_end.split(':') %}
+              {% set start_minute = (start_parts[0] | int) * 60 +
+                                    (start_parts[1] | int) %}
+              {% set end_minute = (end_parts[0] | int) * 60 +
+                                  (end_parts[1] | int) %}
+              {% set effective_start = (start_minute - early_minutes) % 1440 %}
+              {% set current_minute = now().hour * 60 + now().minute %}
+              {{ (effective_start <= end_minute and
+                  effective_start <= current_minute < end_minute) or
+                 (effective_start > end_minute and
+                  (current_minute >= effective_start or current_minute < end_minute)) }}
+          - condition: template
+            value_template: "{{ is_state(occupancy_entity, 'on') }}"
+        sequence:
+          - action: climate.set_hvac_mode
+            target:
+              entity_id: !input dock_climate
+            data:
+              hvac_mode: auto
+          - action: climate.set_temperature
+            target:
+              entity_id: !input dock_climate
+            data:
+              temperature: "{{ night_temperature }}"

--- a/blueprints/automation/sleepme_thermostat/sleep_report_alert.yaml
+++ b/blueprints/automation/sleepme_thermostat/sleep_report_alert.yaml
@@ -133,6 +133,13 @@ triggers:
 
 actions:
   - delay: !input evaluation_delay
+  - condition: template
+    value_template: >-
+      {{ is_number(states(score_entity)) and
+         is_number(states(duration_entity)) and
+         is_number(states(efficiency_entity)) and
+         is_number(states(latency_entity)) and
+         is_number(states(deep_entity)) }}
   - variables:
       sleepme_alert_message: >-
         {% set ns = namespace(items=[]) %}

--- a/blueprints/automation/sleepme_thermostat/sleep_report_alert.yaml
+++ b/blueprints/automation/sleepme_thermostat/sleep_report_alert.yaml
@@ -1,0 +1,164 @@
+blueprint:
+  name: SleepMe Tracker - Sleep report threshold alert
+  description: >-
+    Evaluate the latest completed sleep report and run custom actions when one
+    or more transparent Home Assistant thresholds are missed. The action can
+    use the sleepme_alert_message template variable in notifications.
+  domain: automation
+  author: SleepMe Home Assistant integration
+  source_url: https://github.com/rsampayo/sleepme_thermostat/blob/main/blueprints/automation/sleepme_thermostat/sleep_report_alert.yaml
+  homeassistant:
+    min_version: 2026.1.0
+  input:
+    report_date_sensor:
+      name: Last Sleep Report sensor
+      selector:
+        entity:
+          filter:
+            domain: sensor
+            device_class: date
+    score_sensor:
+      name: Sleep Score sensor
+      selector:
+        entity:
+          filter:
+            domain: sensor
+    duration_sensor:
+      name: Total Sleep Duration sensor
+      selector:
+        entity:
+          filter:
+            domain: sensor
+            device_class: duration
+    efficiency_sensor:
+      name: Sleep Efficiency sensor
+      selector:
+        entity:
+          filter:
+            domain: sensor
+    latency_sensor:
+      name: Sleep Latency sensor
+      selector:
+        entity:
+          filter:
+            domain: sensor
+            device_class: duration
+    deep_sleep_sensor:
+      name: Deep Sleep Percentage sensor
+      selector:
+        entity:
+          filter:
+            domain: sensor
+    minimum_score:
+      name: Minimum sleep score
+      default: 70
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
+    minimum_sleep_hours:
+      name: Minimum sleep duration
+      default: 7
+      selector:
+        number:
+          min: 0
+          max: 16
+          step: 0.25
+          unit_of_measurement: h
+    minimum_efficiency:
+      name: Minimum sleep efficiency
+      default: 85
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
+    maximum_latency_minutes:
+      name: Maximum sleep latency
+      default: 30
+      selector:
+        number:
+          min: 0
+          max: 180
+          step: 5
+          unit_of_measurement: min
+    minimum_deep_sleep_percent:
+      name: Minimum deep sleep
+      default: 10
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
+    evaluation_delay:
+      name: Report sensor settling delay
+      default:
+        seconds: 5
+      selector:
+        duration:
+    alert_actions:
+      name: Alert actions
+      description: Use {{ sleepme_alert_message }} in notification text.
+      selector:
+        action:
+
+mode: queued
+max: 5
+
+variables:
+  score_entity: !input score_sensor
+  duration_entity: !input duration_sensor
+  efficiency_entity: !input efficiency_sensor
+  latency_entity: !input latency_sensor
+  deep_entity: !input deep_sleep_sensor
+  min_score: !input minimum_score
+  min_sleep_hours: !input minimum_sleep_hours
+  min_efficiency: !input minimum_efficiency
+  max_latency_minutes: !input maximum_latency_minutes
+  min_deep_percent: !input minimum_deep_sleep_percent
+
+triggers:
+  - trigger: state
+    entity_id: !input report_date_sensor
+    not_from:
+      - unknown
+      - unavailable
+    not_to:
+      - unknown
+      - unavailable
+
+actions:
+  - delay: !input evaluation_delay
+  - variables:
+      sleepme_alert_message: >-
+        {% set ns = namespace(items=[]) %}
+        {% set score = states(score_entity) | float(101) %}
+        {% set sleep_hours = states(duration_entity) | float(0) / 3600 %}
+        {% set efficiency = states(efficiency_entity) | float(101) %}
+        {% set latency_minutes = states(latency_entity) | float(0) / 60 %}
+        {% set deep_percent = states(deep_entity) | float(101) %}
+        {% if score < min_score %}
+          {% set ns.items = ns.items + ['sleep score ' ~ score | round(0) ~ '%'] %}
+        {% endif %}
+        {% if sleep_hours < min_sleep_hours %}
+          {% set ns.items = ns.items + ['sleep duration ' ~ sleep_hours | round(1) ~ ' h'] %}
+        {% endif %}
+        {% if efficiency < min_efficiency %}
+          {% set ns.items = ns.items + ['efficiency ' ~ efficiency | round(0) ~ '%'] %}
+        {% endif %}
+        {% if latency_minutes > max_latency_minutes %}
+          {% set ns.items = ns.items + ['latency ' ~ latency_minutes | round(0) ~ ' min'] %}
+        {% endif %}
+        {% if deep_percent < min_deep_percent %}
+          {% set ns.items = ns.items + ['deep sleep ' ~ deep_percent | round(0) ~ '%'] %}
+        {% endif %}
+        {{ 'Sleep targets missed: ' ~ ns.items | join(', ') if ns.items else '' }}
+  - condition: template
+    value_template: "{{ sleepme_alert_message | trim != '' }}"
+  - choose:
+      - conditions: "{{ true }}"
+        sequence: !input alert_actions

--- a/blueprints/automation/sleepme_thermostat/tracker_occupancy_actions.yaml
+++ b/blueprints/automation/sleepme_thermostat/tracker_occupancy_actions.yaml
@@ -1,0 +1,62 @@
+blueprint:
+  name: SleepMe Tracker - Occupancy actions
+  description: >-
+    Run arbitrary Home Assistant actions when the SleepMe Tracker detects that
+    someone entered or left the bed. Separate delays suppress brief changes.
+  domain: automation
+  author: SleepMe Home Assistant integration
+  source_url: https://github.com/rsampayo/sleepme_thermostat/blob/main/blueprints/automation/sleepme_thermostat/tracker_occupancy_actions.yaml
+  homeassistant:
+    min_version: 2026.1.0
+  input:
+    occupancy_sensor:
+      name: Tracker occupancy sensor
+      description: Select the SleepMe Tracker User Detected binary sensor.
+      selector:
+        entity:
+          filter:
+            domain: binary_sensor
+    occupied_delay:
+      name: Occupied confirmation delay
+      default:
+        seconds: 0
+      selector:
+        duration:
+    empty_delay:
+      name: Empty confirmation delay
+      default:
+        seconds: 30
+      selector:
+        duration:
+    occupied_actions:
+      name: Actions when occupied
+      default: []
+      selector:
+        action:
+    empty_actions:
+      name: Actions when empty
+      default: []
+      selector:
+        action:
+
+mode: parallel
+max: 10
+
+triggers:
+  - trigger: state
+    entity_id: !input occupancy_sensor
+    to: "on"
+    for: !input occupied_delay
+    id: occupied
+  - trigger: state
+    entity_id: !input occupancy_sensor
+    to: "off"
+    for: !input empty_delay
+    id: empty
+
+actions:
+  - choose:
+      - conditions: "{{ trigger.id == 'occupied' }}"
+        sequence: !input occupied_actions
+      - conditions: "{{ trigger.id == 'empty' }}"
+        sequence: !input empty_actions

--- a/blueprints/automation/sleepme_thermostat/tracker_warm_awake.yaml
+++ b/blueprints/automation/sleepme_thermostat/tracker_warm_awake.yaml
@@ -1,0 +1,100 @@
+blueprint:
+  name: SleepMe Tracker + Dock - Warm-awake routine
+  description: >-
+    Reproduce a transparent Warm Awake routine in Home Assistant: shortly
+    before the configured wake time, warm an occupied bed for a fixed duration
+    and then turn the Dock off. This uses Tracker occupancy and deterministic
+    HA rules, not a Sleepme cloud program.
+  domain: automation
+  author: SleepMe Home Assistant integration
+  source_url: https://github.com/rsampayo/sleepme_thermostat/blob/main/blueprints/automation/sleepme_thermostat/tracker_warm_awake.yaml
+  homeassistant:
+    min_version: 2026.1.0
+  input:
+    occupancy_sensor:
+      name: Tracker occupancy sensor
+      selector:
+        entity:
+          filter:
+            domain: binary_sensor
+    dock_climate:
+      name: Dock climate entity
+      selector:
+        entity:
+          filter:
+            domain: climate
+            integration: sleepme_thermostat
+    wake_time:
+      name: Wake time
+      default: "07:00:00"
+      selector:
+        time:
+    preheat_minutes:
+      name: Start before wake time
+      description: Sleepme documents a 15-minute Warm Awake lead time.
+      default: 15
+      selector:
+        number:
+          min: 0
+          max: 120
+          step: 1
+          unit_of_measurement: min
+          mode: box
+    warm_temperature:
+      name: Warm-awake temperature
+      description: Enter this in Home Assistant's configured temperature unit.
+      default: 32
+      selector:
+        number:
+          min: 0
+          max: 120
+          step: 0.5
+          mode: box
+    warm_duration:
+      name: Warm duration
+      description: Sleepme documents a 20-minute Warm Awake duration.
+      default:
+        minutes: 20
+      selector:
+        duration:
+
+mode: single
+
+variables:
+  occupancy_entity: !input occupancy_sensor
+  dock_entity: !input dock_climate
+  configured_wake: !input wake_time
+  lead_minutes: !input preheat_minutes
+  target_temperature: !input warm_temperature
+
+triggers:
+  - trigger: time_pattern
+    minutes: "*"
+
+conditions:
+  - condition: template
+    value_template: >-
+      {% set wake_parts = configured_wake.split(':') %}
+      {% set wake_minute = (wake_parts[0] | int) * 60 + (wake_parts[1] | int) %}
+      {% set start_minute = (wake_minute - lead_minutes) % 1440 %}
+      {{ now().hour * 60 + now().minute == start_minute }}
+  - condition: template
+    value_template: >-
+      {{ is_state(occupancy_entity, 'on') and
+         states(dock_entity) not in ['unknown', 'unavailable'] }}
+
+actions:
+  - action: climate.set_hvac_mode
+    target:
+      entity_id: !input dock_climate
+    data:
+      hvac_mode: auto
+  - action: climate.set_temperature
+    target:
+      entity_id: !input dock_climate
+    data:
+      temperature: "{{ target_temperature }}"
+  - delay: !input warm_duration
+  - action: climate.turn_off
+    target:
+      entity_id: !input dock_climate

--- a/custom_components/sleepme_thermostat/__init__.py
+++ b/custom_components/sleepme_thermostat/__init__.py
@@ -38,6 +38,7 @@ from .const import (
     DOMAIN,
     MAX_SLEEP_REPORT_DAYS_BACK,
     SERVICE_GET_SLEEP_REPORTS,
+    SLEEP_REPORT_HISTORY_DAYS,
 )
 from .helpers import is_sleep_tracker
 from .sleepme import SleepMeClient
@@ -155,7 +156,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SleepMeConfigEntry) -> b
             API_URL,
             api_token,
             time_zone=hass.config.time_zone,
-            days_back=DEFAULT_SLEEP_REPORT_DAYS_BACK,
+            history_days=SLEEP_REPORT_HISTORY_DAYS,
             scan_interval=DEFAULT_SLEEP_REPORT_SCAN_INTERVAL,
         )
         await report_coordinator.async_config_entry_first_refresh()

--- a/custom_components/sleepme_thermostat/__init__.py
+++ b/custom_components/sleepme_thermostat/__init__.py
@@ -1,27 +1,64 @@
-"""SleepMe Thermostat custom integration."""
+"""SleepMe custom integration."""
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import date
+from typing import cast
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+import httpx
+import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+)
+from homeassistant.exceptions import (
+    ConfigEntryNotReady,
+    HomeAssistantError,
+    ServiceValidationError,
+)
 from homeassistant.helpers import config_validation as cv
+from homeassistant.util import dt as dt_util
+from homeassistant.util.json import JsonArrayType
 
 from .const import (
     API_URL,
+    ATTR_CONFIG_ENTRY_ID,
+    ATTR_DAYS_BACK,
+    ATTR_START_DATE,
+    ATTR_TIME_ZONE,
     CONF_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_SLEEP_REPORT_DAYS_BACK,
+    DEFAULT_SLEEP_REPORT_SCAN_INTERVAL,
     DOMAIN,
+    MAX_SLEEP_REPORT_DAYS_BACK,
+    SERVICE_GET_SLEEP_REPORTS,
 )
+from .helpers import is_sleep_tracker
 from .sleepme import SleepMeClient
-from .update_manager import SleepMeUpdateManager
+from .sleepme_api import SleepMeAPIError
+from .update_manager import SleepMeUpdateManager, SleepReportUpdateManager
 
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+GET_SLEEP_REPORTS_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string,
+        vol.Optional(ATTR_START_DATE): cv.date,
+        vol.Optional(ATTR_DAYS_BACK, default=DEFAULT_SLEEP_REPORT_DAYS_BACK): vol.All(
+            vol.Coerce(int),
+            vol.Range(min=0, max=MAX_SLEEP_REPORT_DAYS_BACK),
+        ),
+        vol.Optional(ATTR_TIME_ZONE): cv.string,
+    }
+)
 
 PLATFORMS = ["climate", "binary_sensor", "sensor"]
 
@@ -36,6 +73,7 @@ class SleepMeData:
 
     client: SleepMeClient
     coordinator: SleepMeUpdateManager
+    report_coordinator: SleepReportUpdateManager | None
     # Raw fields from entry.data; helpers.build_device_info() maps them into
     # HA's DeviceInfo TypedDict shape at platform-setup time.
     device_info: dict
@@ -46,12 +84,52 @@ type SleepMeConfigEntry = ConfigEntry[SleepMeData]
 
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
-    """Set up the SleepMe Thermostat component (YAML hook — unused)."""
+    """Set up integration-level actions."""
+
+    async def async_get_sleep_reports(call: ServiceCall) -> ServiceResponse:
+        """Return the requested raw report window without recorder overhead."""
+        entry = hass.config_entries.async_get_entry(call.data[ATTR_CONFIG_ENTRY_ID])
+        if entry is None or entry.domain != DOMAIN:
+            raise ServiceValidationError("SleepMe config entry not found")
+        if entry.state is not ConfigEntryState.LOADED:
+            raise ServiceValidationError("SleepMe config entry is not loaded")
+
+        sleepme_entry = cast(SleepMeConfigEntry, entry)
+        time_zone = call.data.get(ATTR_TIME_ZONE, hass.config.time_zone)
+        zone = dt_util.get_time_zone(time_zone)
+        if zone is None:
+            raise ServiceValidationError(f"Unknown IANA time zone: {time_zone}")
+        start_date: date = call.data.get(ATTR_START_DATE, dt_util.now(zone).date())
+
+        try:
+            reports = await sleepme_entry.runtime_data.client.get_sleep_reports(
+                start_date=start_date,
+                days_back=call.data[ATTR_DAYS_BACK],
+                time_zone=time_zone,
+            )
+        except SleepMeAPIError as err:
+            raise HomeAssistantError(
+                f"Could not fetch SleepMe sleep reports: {err}"
+            ) from err
+        except httpx.HTTPError as err:
+            raise HomeAssistantError("Could not fetch SleepMe sleep reports") from err
+        except ValueError as err:
+            raise HomeAssistantError(str(err)) from err
+
+        return {"reports": cast(JsonArrayType, reports)}
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_SLEEP_REPORTS,
+        async_get_sleep_reports,
+        schema=GET_SLEEP_REPORTS_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: SleepMeConfigEntry) -> bool:
-    """Set up SleepMe Thermostat from a config entry."""
+    """Set up a SleepMe device from a config entry."""
     api_token = entry.data.get("api_token")
     device_id = entry.data.get("device_id")
 
@@ -69,9 +147,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: SleepMeConfigEntry) -> b
     # ConfigEntryNotReady (-> HA retries setup) without further plumbing.
     await coordinator.async_config_entry_first_refresh()
 
+    model = entry.data.get("model") or coordinator.data["about"].get("model")
+    report_coordinator: SleepReportUpdateManager | None = None
+    if is_sleep_tracker(model):
+        report_coordinator = SleepReportUpdateManager(
+            hass,
+            API_URL,
+            api_token,
+            time_zone=hass.config.time_zone,
+            days_back=DEFAULT_SLEEP_REPORT_DAYS_BACK,
+            scan_interval=DEFAULT_SLEEP_REPORT_SCAN_INTERVAL,
+        )
+        await report_coordinator.async_config_entry_first_refresh()
+
     entry.runtime_data = SleepMeData(
         client=client,
         coordinator=coordinator,
+        report_coordinator=report_coordinator,
         device_info={
             "firmware_version": entry.data.get("firmware_version"),
             "mac_address": entry.data.get("mac_address"),
@@ -103,8 +195,8 @@ async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> Non
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate old config entries to the current schema.
 
-    v3 -> v4: drop `api_url` (always equals API_URL) and `name` (duplicates
-    the suffix of `entry.title`).
+    v3 -> v4: drop `api_url` (always equals API_URL) and `name`.
+    v4 -> v5: recognize existing ST501NA entries as Sleep Trackers.
     """
     _LOGGER.debug(
         "Migrating SleepMe entry %s from version %s", entry.entry_id, entry.version
@@ -117,6 +209,19 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "Migrated SleepMe entry %s to schema v4 (dropped api_url, name)",
             entry.entry_id,
         )
+
+    if entry.version < 5:
+        new_title = entry.title
+        if is_sleep_tracker(entry.data.get("model")) and entry.title.startswith(
+            "Dock Pro "
+        ):
+            new_title = f"Sleep Tracker {entry.title.removeprefix('Dock Pro ')}"
+        hass.config_entries.async_update_entry(
+            entry,
+            title=new_title,
+            version=5,
+        )
+        _LOGGER.info("Migrated SleepMe entry %s to schema v5", entry.entry_id)
 
     return True
 

--- a/custom_components/sleepme_thermostat/__init__.py
+++ b/custom_components/sleepme_thermostat/__init__.py
@@ -159,7 +159,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: SleepMeConfigEntry) -> b
             history_days=SLEEP_REPORT_HISTORY_DAYS,
             scan_interval=DEFAULT_SLEEP_REPORT_SCAN_INTERVAL,
         )
-        await report_coordinator.async_config_entry_first_refresh()
+        try:
+            await report_coordinator.async_config_entry_first_refresh()
+        except ConfigEntryNotReady as err:
+            # Reports are useful but should not take down live occupancy and
+            # environment data. CoordinatorEntity subscriptions will keep
+            # retrying; authentication failures still propagate as reauth.
+            _LOGGER.warning(
+                "Sleep reports unavailable during setup; live Tracker data will "
+                "remain available and reports will retry: %s",
+                err,
+            )
 
     entry.runtime_data = SleepMeData(
         client=client,

--- a/custom_components/sleepme_thermostat/binary_sensor.py
+++ b/custom_components/sleepme_thermostat/binary_sensor.py
@@ -1,4 +1,4 @@
-"""Binary sensors for SleepMe Dock Pro: water-level-low + connected."""
+"""Binary sensors for SleepMe devices."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .helpers import build_device_info
+from .helpers import build_device_info, is_sleep_tracker
 
 if TYPE_CHECKING:
     from .update_manager import SleepMeUpdateManager
@@ -27,17 +27,21 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up SleepMe Thermostat binary sensors from a config entry."""
+    """Set up SleepMe binary sensors from a config entry."""
     device_id: str = entry.data["device_id"]
     data = entry.runtime_data
     device_info = build_device_info(device_id, entry.title, data.device_info)
 
-    async_add_entities(
-        [
-            WaterLevelLowSensor(data.coordinator, device_id, device_info),
-            DeviceConnectedBinarySensor(data.coordinator, device_id, device_info),
-        ]
-    )
+    entities: list[BinarySensorEntity] = [
+        DeviceConnectedBinarySensor(data.coordinator, device_id, device_info)
+    ]
+    if is_sleep_tracker(entry.data.get("model")):
+        entities.append(
+            UserDetectedBinarySensor(data.coordinator, device_id, device_info)
+        )
+    else:
+        entities.append(WaterLevelLowSensor(data.coordinator, device_id, device_info))
+    async_add_entities(entities)
 
 
 class WaterLevelLowSensor(CoordinatorEntity, BinarySensorEntity):
@@ -87,3 +91,26 @@ class DeviceConnectedBinarySensor(CoordinatorEntity, BinarySensorEntity):
     def is_on(self) -> bool | None:
         """Return true if the device is connected."""
         return self.coordinator.data["status"].get("is_connected")
+
+
+class UserDetectedBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Binary sensor: the tracker currently detects a sleeper in bed."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Bed Occupancy"
+    _attr_device_class = BinarySensorDeviceClass.OCCUPANCY
+
+    def __init__(
+        self,
+        coordinator: SleepMeUpdateManager,
+        device_id: str,
+        device_info: DeviceInfo,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{DOMAIN}_{device_id}_user_detected"
+        self._attr_device_info = device_info
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true while the tracker detects a user."""
+        return self.coordinator.data["status"].get("user_detected")

--- a/custom_components/sleepme_thermostat/climate.py
+++ b/custom_components/sleepme_thermostat/climate.py
@@ -44,7 +44,7 @@ from .const import (
     PRESET_MAX_HEAT,
     PRESET_TEMPERATURES,
 )
-from .helpers import build_device_info, round_half_up
+from .helpers import build_device_info, is_sleep_tracker, round_half_up
 from .sleepme_api import (
     SleepMeAPIError,
     SleepMeAuthError,
@@ -69,8 +69,10 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up SleepMe Thermostat climate entity from a config entry."""
+    """Set up a SleepMe climate entity from a config entry."""
     device_id: str = entry.data["device_id"]
+    if is_sleep_tracker(entry.data.get("model")):
+        return
     data = entry.runtime_data
     device_info = build_device_info(device_id, entry.title, data.device_info)
 

--- a/custom_components/sleepme_thermostat/config_flow.py
+++ b/custom_components/sleepme_thermostat/config_flow.py
@@ -8,6 +8,7 @@ from typing import Any
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry, ConfigFlowResult, OptionsFlow
+from homeassistant.const import UnitOfTime
 from homeassistant.core import callback
 from homeassistant.helpers import selector
 
@@ -238,7 +239,7 @@ class SleepMeOptionsFlowHandler(OptionsFlow):
                     min=0,
                     max=86400,
                     step=1,
-                    unit_of_measurement="seconds",
+                    unit_of_measurement=UnitOfTime.SECONDS,
                     mode=selector.NumberSelectorMode.BOX,
                 )
             ),
@@ -253,7 +254,7 @@ class SleepMeOptionsFlowHandler(OptionsFlow):
                         min=0,
                         max=24,
                         step=0.25,
-                        unit_of_measurement="hours",
+                        unit_of_measurement=UnitOfTime.HOURS,
                         mode=selector.NumberSelectorMode.BOX,
                     )
                 )

--- a/custom_components/sleepme_thermostat/config_flow.py
+++ b/custom_components/sleepme_thermostat/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for SleepMe Thermostat."""
+"""Config flow for SleepMe devices."""
 
 from __future__ import annotations
 
@@ -19,6 +19,7 @@ from .const import (
     MAX_SCAN_INTERVAL,
     MIN_SCAN_INTERVAL,
 )
+from .helpers import is_sleep_tracker
 from .sleepme import SleepMeClient
 from .sleepme_api import (
     SleepMeAuthError,
@@ -30,9 +31,9 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class SleepMeThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for SleepMe Thermostat."""
+    """Handle a config flow for SleepMe devices."""
 
-    VERSION = 4
+    VERSION = 5
 
     def __init__(self) -> None:
         self.api_token: str = ""
@@ -106,8 +107,12 @@ class SleepMeThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             try:
                 device_status = await client.get_device_status()
+                model = device_status.get("about", {}).get("model")
+                product_name = (
+                    "Sleep Tracker" if is_sleep_tracker(model) else "Dock Pro"
+                )
                 return self.async_create_entry(
-                    title=f"Dock Pro {name}",
+                    title=f"{product_name} {name}",
                     data={
                         "api_token": self.api_token,
                         "device_id": device_id,
@@ -117,7 +122,7 @@ class SleepMeThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         "mac_address": device_status.get("about", {}).get(
                             "mac_address"
                         ),
-                        "model": device_status.get("about", {}).get("model"),
+                        "model": model,
                         "serial_number": device_status.get("about", {}).get(
                             "serial_number"
                         ),

--- a/custom_components/sleepme_thermostat/config_flow.py
+++ b/custom_components/sleepme_thermostat/config_flow.py
@@ -14,10 +14,14 @@ from homeassistant.helpers import selector
 from .const import (
     API_URL,
     CONF_SCAN_INTERVAL,
+    CONF_SLEEP_TARGET_HOURS,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_SLEEP_TARGET_HOURS,
     DOMAIN,
     MAX_SCAN_INTERVAL,
+    MAX_SLEEP_TARGET_HOURS,
     MIN_SCAN_INTERVAL,
+    MIN_SLEEP_TARGET_HOURS,
 )
 from .helpers import is_sleep_tracker
 from .sleepme import SleepMeClient
@@ -195,7 +199,7 @@ class SleepMeThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 
 class SleepMeOptionsFlowHandler(OptionsFlow):
-    """Options flow: poll interval only (Phase 2).
+    """Options flow for polling and tracker-derived sleep goals.
 
     `self.config_entry` is set automatically by HA's framework — do not assign
     it in __init__ (the attribute is read-only in HA Core 2024.12+).
@@ -206,11 +210,18 @@ class SleepMeOptionsFlowHandler(OptionsFlow):
     ) -> ConfigFlowResult:
         """Show + handle the options form."""
         errors: dict[str, str] = {}
+        tracker = is_sleep_tracker(self.config_entry.data.get("model"))
 
         if user_input is not None:
             value = user_input[CONF_SCAN_INTERVAL]
             if not MIN_SCAN_INTERVAL <= value <= MAX_SCAN_INTERVAL:
                 errors[CONF_SCAN_INTERVAL] = "invalid_scan_interval"
+            elif tracker and not (
+                MIN_SLEEP_TARGET_HOURS
+                <= user_input[CONF_SLEEP_TARGET_HOURS]
+                <= MAX_SLEEP_TARGET_HOURS
+            ):
+                errors[CONF_SLEEP_TARGET_HOURS] = "invalid_sleep_target"
             else:
                 return self.async_create_entry(title="", data=user_input)
 
@@ -221,21 +232,33 @@ class SleepMeOptionsFlowHandler(OptionsFlow):
         # below is the single source of truth for the allowed range. Bound
         # enforcement at the schema layer would prevent our `invalid_scan_interval`
         # error key from surfacing in the form.
-        schema = vol.Schema(
-            {
-                vol.Required(
-                    CONF_SCAN_INTERVAL, default=current
-                ): selector.NumberSelector(
+        fields: dict[Any, Any] = {
+            vol.Required(CONF_SCAN_INTERVAL, default=current): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0,
+                    max=86400,
+                    step=1,
+                    unit_of_measurement="seconds",
+                    mode=selector.NumberSelectorMode.BOX,
+                )
+            ),
+        }
+        if tracker:
+            current_target = self.config_entry.options.get(
+                CONF_SLEEP_TARGET_HOURS, DEFAULT_SLEEP_TARGET_HOURS
+            )
+            fields[vol.Required(CONF_SLEEP_TARGET_HOURS, default=current_target)] = (
+                selector.NumberSelector(
                     selector.NumberSelectorConfig(
                         min=0,
-                        max=86400,
-                        step=1,
-                        unit_of_measurement="seconds",
+                        max=24,
+                        step=0.25,
+                        unit_of_measurement="hours",
                         mode=selector.NumberSelectorMode.BOX,
                     )
-                ),
-            }
-        )
+                )
+            )
+        schema = vol.Schema(fields)
         return self.async_show_form(
             step_id="init",
             data_schema=schema,

--- a/custom_components/sleepme_thermostat/const.py
+++ b/custom_components/sleepme_thermostat/const.py
@@ -2,6 +2,22 @@ API_URL = "https://api.developer.sleep.me/v1"
 
 DOMAIN = "sleepme_thermostat"
 
+MODEL_SLEEP_TRACKER = "ST501NA"
+
+SERVICE_GET_SLEEP_REPORTS = "get_sleep_reports"
+ATTR_CONFIG_ENTRY_ID = "config_entry_id"
+ATTR_START_DATE = "start_date"
+ATTR_DAYS_BACK = "days_back"
+ATTR_TIME_ZONE = "time_zone"
+
+# The public API accepts the requested date plus at most six preceding days.
+# Sleep reports are finalized after the sleeper has been out of bed for roughly
+# 15 minutes, so a separate 30-minute coordinator is responsive without spending
+# the scarce per-account request budget on every live-device poll.
+MAX_SLEEP_REPORT_DAYS_BACK = 6
+DEFAULT_SLEEP_REPORT_DAYS_BACK = 6
+DEFAULT_SLEEP_REPORT_SCAN_INTERVAL = 30 * 60
+
 PRESET_MAX_COOL = "Max Cool"
 PRESET_MAX_HEAT = "Max Heat"
 

--- a/custom_components/sleepme_thermostat/const.py
+++ b/custom_components/sleepme_thermostat/const.py
@@ -32,9 +32,21 @@ MAX_TEMP_C = 48.0
 
 # Options flow
 CONF_SCAN_INTERVAL = "scan_interval"
+CONF_SLEEP_TARGET_HOURS = "sleep_target_hours"
 # 30s default keeps 3-device installs comfortably under the 9 req/min
 # per-account ceiling (3 * 60/30 = 6 req/min). v4.1.0 release notes asked
 # multi-device users to bump this manually; v4.1.1 makes it the default.
 DEFAULT_SCAN_INTERVAL = 30
 MIN_SCAN_INTERVAL = 10
 MAX_SCAN_INTERVAL = 300
+
+# Used only for HA-derived goal/debt sensors. Sleepme does not prescribe this
+# value and users can change it in the integration options.
+DEFAULT_SLEEP_TARGET_HOURS = 8.0
+MIN_SLEEP_TARGET_HOURS = 4.0
+MAX_SLEEP_TARGET_HOURS = 12.0
+
+# The endpoint returns at most seven dates per call. The report coordinator
+# pages across five non-overlapping windows every 30 minutes so rolling metrics
+# can cover a full month without increasing the live-device polling cadence.
+SLEEP_REPORT_HISTORY_DAYS = 30

--- a/custom_components/sleepme_thermostat/diagnostics.py
+++ b/custom_components/sleepme_thermostat/diagnostics.py
@@ -1,12 +1,10 @@
-"""Diagnostics support for SleepMe Thermostat.
+"""Diagnostics support for SleepMe devices.
 
 Exposed through HA's "Download diagnostics" UI on the device page.
 
-The api_token is redacted; everything else (coordinator data, entry options,
-device info) is included verbatim so support requests carry enough state to
-reproduce a bug without follow-up. MAC, IP, LAN, serial are also redacted by
-default to make the output safer to paste verbatim into a GitHub issue —
-narrow `TO_REDACT` if you need them visible during real debugging.
+The api_token is redacted. MAC, IP, LAN, and serial are also redacted by
+default. Sleep reports are health data, so diagnostics include only report
+coordinator health and counts, never sessions or hypnogram payloads.
 """
 
 from __future__ import annotations
@@ -33,6 +31,7 @@ async def async_get_config_entry_diagnostics(
     data = getattr(entry, "runtime_data", None)
 
     coordinator_payload: dict[str, Any] = {}
+    report_coordinator_payload: dict[str, Any] | None = None
     device_info: dict[str, Any] = {}
     if data is not None:
         coordinator = data.coordinator
@@ -51,6 +50,23 @@ async def async_get_config_entry_diagnostics(
             "data": coordinator.data or {},
         }
         device_info = dict(data.device_info)
+        if data.report_coordinator is not None:
+            report_coordinator = data.report_coordinator
+            reports = report_coordinator.data or []
+            report_coordinator_payload = {
+                "update_interval_seconds": (
+                    report_coordinator.update_interval.total_seconds()
+                    if report_coordinator.update_interval is not None
+                    else None
+                ),
+                "last_update_success": report_coordinator.last_update_success,
+                "last_exception": (
+                    repr(report_coordinator.last_exception)
+                    if report_coordinator.last_exception is not None
+                    else None
+                ),
+                "report_count": len(reports),
+            }
 
     return {
         "entry": {
@@ -61,4 +77,5 @@ async def async_get_config_entry_diagnostics(
         },
         "device_info": async_redact_data(device_info, TO_REDACT),
         "coordinator": async_redact_data(coordinator_payload, TO_REDACT),
+        "report_coordinator": report_coordinator_payload,
     }

--- a/custom_components/sleepme_thermostat/helpers.py
+++ b/custom_components/sleepme_thermostat/helpers.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 
-from .const import DOMAIN
+from .const import DOMAIN, MODEL_SLEEP_TRACKER
 
 
 def round_half_up(n: float) -> float:
     """Round a number to the nearest .0 or .5."""
     return round(n * 2) / 2
+
+
+def is_sleep_tracker(model: str | None) -> bool:
+    """Return whether a Sleepme model identifier is the ST501NA tracker."""
+    return bool(model and model.upper() == MODEL_SLEEP_TRACKER)
 
 
 def build_device_info(device_id: str, display_name: str, info: dict) -> DeviceInfo:

--- a/custom_components/sleepme_thermostat/manifest.json
+++ b/custom_components/sleepme_thermostat/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "sleepme_thermostat",
-  "name": "SleepMe (Chilipad Dock Pro)",
-  "codeowners": ["@rsampayo", "@mikesalz","@derekcentrico"],
+  "name": "SleepMe",
+  "codeowners": ["@rsampayo", "@mikesalz", "@derekcentrico"],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/rsampayo/sleepme_thermostat",
@@ -11,5 +11,5 @@
   "loggers": ["custom_components.sleepme_thermostat"],
   "quality_scale": "silver",
   "requirements": [],
-  "version": "4.2.0"
+  "version": "4.3.0"
 }

--- a/custom_components/sleepme_thermostat/sensor.py
+++ b/custom_components/sleepme_thermostat/sensor.py
@@ -1,19 +1,29 @@
-"""Diagnostic sensors for SleepMe Dock Pro: IP, LAN, brightness, display unit, time zone."""
+"""Sensors for SleepMe climate systems and sleep trackers."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from datetime import date, datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PERCENTAGE, UnitOfTemperature, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .helpers import build_device_info
+from .helpers import build_device_info, is_sleep_tracker
+from .sleep_reports import latest_sleep_report, summarize_sleep_report
+from .update_manager import SleepReportUpdateManager
 
 if TYPE_CHECKING:
     from .update_manager import SleepMeUpdateManager
@@ -24,22 +34,46 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up SleepMe Thermostat diagnostic sensors from a config entry."""
+    """Set up SleepMe sensors from a config entry."""
     device_id: str = entry.data["device_id"]
     data = entry.runtime_data
     device_info = build_device_info(device_id, entry.title, data.device_info)
 
-    async_add_entities(
-        [
-            IPAddressSensor(data.coordinator, device_id, device_info),
-            LANAddressSensor(data.coordinator, device_id, device_info),
-            BrightnessLevelSensor(data.coordinator, device_id, device_info),
-            DisplayTemperatureUnitSensor(data.coordinator, device_id, device_info),
-            TimeZoneSensor(data.coordinator, device_id, device_info),
-            WaterLevelSensor(data.coordinator, device_id, device_info),
-            FirmwareVersionSensor(data.coordinator, device_id, device_info),
-        ]
-    )
+    entities: list[SensorEntity] = [
+        IPAddressSensor(data.coordinator, device_id, device_info),
+        LANAddressSensor(data.coordinator, device_id, device_info),
+        FirmwareVersionSensor(data.coordinator, device_id, device_info),
+    ]
+
+    if is_sleep_tracker(entry.data.get("model")):
+        entities.extend(
+            [
+                TrackerEnvironmentHumiditySensor(
+                    data.coordinator, device_id, device_info
+                ),
+                TrackerEnvironmentTemperatureSensor(
+                    data.coordinator, device_id, device_info
+                ),
+                TrackerBedTemperatureSensor(data.coordinator, device_id, device_info),
+            ]
+        )
+        if data.report_coordinator is not None:
+            entities.extend(
+                _build_sleep_report_sensors(
+                    data.report_coordinator, device_id, device_info
+                )
+            )
+    else:
+        entities.extend(
+            [
+                BrightnessLevelSensor(data.coordinator, device_id, device_info),
+                DisplayTemperatureUnitSensor(data.coordinator, device_id, device_info),
+                TimeZoneSensor(data.coordinator, device_id, device_info),
+                WaterLevelSensor(data.coordinator, device_id, device_info),
+            ]
+        )
+
+    async_add_entities(entities)
 
 
 class _SleepMeDiagnosticSensor(CoordinatorEntity, SensorEntity):
@@ -235,3 +269,207 @@ class FirmwareVersionSensor(_SleepMeDiagnosticSensor):
     @property
     def native_value(self) -> str | int | None:
         return self.coordinator.data["about"].get("firmware_version")
+
+
+class _SleepMeTrackerSensor(CoordinatorEntity, SensorEntity):
+    """Base for live, non-diagnostic tracker measurements."""
+
+    _attr_has_entity_name = True
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        coordinator: SleepMeUpdateManager,
+        device_id: str,
+        device_info: DeviceInfo,
+        *,
+        suffix: str,
+        label: str,
+        status_key: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._status_key = status_key
+        self._attr_name = label
+        self._attr_unique_id = f"{DOMAIN}_{device_id}_{suffix}"
+        self._attr_device_info = device_info
+
+    @property
+    def native_value(self) -> int | float | None:
+        """Return the live tracker status value."""
+        return self.coordinator.data["status"].get(self._status_key)
+
+
+class TrackerEnvironmentHumiditySensor(_SleepMeTrackerSensor):
+    """Current room humidity measured by the tracker hub."""
+
+    _attr_device_class = SensorDeviceClass.HUMIDITY
+    _attr_native_unit_of_measurement = PERCENTAGE
+
+    def __init__(
+        self,
+        coordinator: SleepMeUpdateManager,
+        device_id: str,
+        device_info: DeviceInfo,
+    ) -> None:
+        super().__init__(
+            coordinator,
+            device_id,
+            device_info,
+            suffix="environment_humidity",
+            label="Environment Humidity",
+            status_key="environment_humidity",
+        )
+
+
+class TrackerEnvironmentTemperatureSensor(_SleepMeTrackerSensor):
+    """Current room temperature measured by the tracker hub."""
+
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+
+    def __init__(
+        self,
+        coordinator: SleepMeUpdateManager,
+        device_id: str,
+        device_info: DeviceInfo,
+    ) -> None:
+        super().__init__(
+            coordinator,
+            device_id,
+            device_info,
+            suffix="environment_temperature",
+            label="Environment Temperature",
+            status_key="environment_temperature_c",
+        )
+
+
+class TrackerBedTemperatureSensor(_SleepMeTrackerSensor):
+    """Current in-bed temperature measured by the tracker pad."""
+
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+
+    def __init__(
+        self,
+        coordinator: SleepMeUpdateManager,
+        device_id: str,
+        device_info: DeviceInfo,
+    ) -> None:
+        super().__init__(
+            coordinator,
+            device_id,
+            device_info,
+            suffix="bed_temperature",
+            label="Bed Temperature",
+            status_key="bed_temperature_c",
+        )
+
+
+class SleepReportSensor(CoordinatorEntity[SleepReportUpdateManager], SensorEntity):
+    """One aggregate field from the latest completed daily sleep report."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: SleepReportUpdateManager,
+        device_id: str,
+        device_info: DeviceInfo,
+        *,
+        key: str,
+        label: str,
+        device_class: SensorDeviceClass | None = None,
+        unit: str | None = None,
+        state_class: SensorStateClass | None = None,
+        icon: str | None = None,
+    ) -> None:
+        super().__init__(coordinator)
+        self._key = key
+        self._attr_name = label
+        self._attr_unique_id = f"{DOMAIN}_{device_id}_sleep_report_{key}"
+        self._attr_device_info = device_info
+        self._attr_device_class = device_class
+        self._attr_native_unit_of_measurement = unit
+        self._attr_state_class = state_class
+        self._attr_icon = icon
+
+    @property
+    def native_value(self) -> StateType | date | datetime | Decimal:
+        """Return the latest report summary value for this sensor."""
+        report = latest_sleep_report(self.coordinator.data or [])
+        return summarize_sleep_report(report).get(self._key)
+
+
+def _build_sleep_report_sensors(
+    coordinator: SleepReportUpdateManager,
+    device_id: str,
+    device_info: DeviceInfo,
+) -> list[SleepReportSensor]:
+    """Build all aggregate sensors backed by the public report schema."""
+    definitions: list[dict[str, Any]] = [
+        {
+            "key": "date",
+            "label": "Last Sleep Report",
+            "device_class": SensorDeviceClass.DATE,
+        },
+        {
+            "key": "sleep_score_percent",
+            "label": "Sleep Score",
+            "unit": PERCENTAGE,
+            "state_class": SensorStateClass.MEASUREMENT,
+            "icon": "mdi:sleep",
+        },
+        {
+            "key": "session_count",
+            "label": "Sleep Sessions",
+            "state_class": SensorStateClass.MEASUREMENT,
+            "icon": "mdi:counter",
+        },
+        {
+            "key": "enter_bed_time",
+            "label": "Entered Bed",
+            "device_class": SensorDeviceClass.TIMESTAMP,
+        },
+        {
+            "key": "exit_bed_time",
+            "label": "Exited Bed",
+            "device_class": SensorDeviceClass.TIMESTAMP,
+        },
+    ]
+    duration_labels = {
+        "total_session_duration": "Total Session Duration",
+        "in_bed_duration": "In-bed Duration",
+        "total_sleep_duration": "Total Sleep Duration",
+        "awake_duration": "Awake Duration",
+        "light_sleep_duration": "Light Sleep Duration",
+        "rem_sleep_duration": "REM Sleep Duration",
+        "deep_sleep_duration": "Deep Sleep Duration",
+        "sleep_latency": "Sleep Latency",
+    }
+    definitions.extend(
+        {
+            "key": key,
+            "label": label,
+            "device_class": SensorDeviceClass.DURATION,
+            "unit": UnitOfTime.SECONDS,
+            "state_class": SensorStateClass.MEASUREMENT,
+        }
+        for key, label in duration_labels.items()
+    )
+    definitions.append(
+        {
+            "key": "hypnogram_segment_count",
+            "label": "Hypnogram Segments",
+            "state_class": SensorStateClass.MEASUREMENT,
+            "icon": "mdi:chart-timeline-variant",
+        }
+    )
+    return [
+        SleepReportSensor(
+            coordinator,
+            device_id,
+            device_info,
+            **definition,
+        )
+        for definition in definitions
+    ]

--- a/custom_components/sleepme_thermostat/sensor.py
+++ b/custom_components/sleepme_thermostat/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -20,9 +20,17 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import (
+    CONF_SLEEP_TARGET_HOURS,
+    DEFAULT_SLEEP_TARGET_HOURS,
+    DOMAIN,
+)
 from .helpers import build_device_info, is_sleep_tracker
-from .sleep_reports import latest_sleep_report, summarize_sleep_report
+from .sleep_reports import (
+    latest_sleep_report,
+    summarize_sleep_history,
+    summarize_sleep_report,
+)
 from .update_manager import SleepReportUpdateManager
 
 if TYPE_CHECKING:
@@ -58,9 +66,16 @@ async def async_setup_entry(
             ]
         )
         if data.report_coordinator is not None:
+            sleep_target_seconds = (
+                entry.options.get(CONF_SLEEP_TARGET_HOURS, DEFAULT_SLEEP_TARGET_HOURS)
+                * 3600
+            )
             entities.extend(
                 _build_sleep_report_sensors(
-                    data.report_coordinator, device_id, device_info
+                    data.report_coordinator,
+                    device_id,
+                    device_info,
+                    sleep_target_seconds=sleep_target_seconds,
                 )
             )
     else:
@@ -382,30 +397,49 @@ class SleepReportSensor(CoordinatorEntity[SleepReportUpdateManager], SensorEntit
         unit: str | None = None,
         state_class: SensorStateClass | None = None,
         icon: str | None = None,
+        scope: Literal["latest", "history"] = "latest",
+        sleep_target_seconds: float = DEFAULT_SLEEP_TARGET_HOURS * 3600,
+        enabled_default: bool = True,
     ) -> None:
         super().__init__(coordinator)
         self._key = key
-        self._attr_name = label
+        # Keep the English label beside the entity definition for maintainers,
+        # while HA resolves the displayed name through strings.json and the
+        # active frontend language (falling back to English when untranslated).
+        self._english_label = label
+        self._attr_translation_key = key
         self._attr_unique_id = f"{DOMAIN}_{device_id}_sleep_report_{key}"
         self._attr_device_info = device_info
         self._attr_device_class = device_class
         self._attr_native_unit_of_measurement = unit
         self._attr_state_class = state_class
         self._attr_icon = icon
+        self._scope = scope
+        self._sleep_target_seconds = sleep_target_seconds
+        self._attr_entity_registry_enabled_default = enabled_default
 
     @property
     def native_value(self) -> StateType | date | datetime | Decimal:
         """Return the latest report summary value for this sensor."""
+        if self._scope == "history":
+            return summarize_sleep_history(
+                self.coordinator.data or [],
+                sleep_target_seconds=self._sleep_target_seconds,
+            ).get(self._key)
         report = latest_sleep_report(self.coordinator.data or [])
-        return summarize_sleep_report(report).get(self._key)
+        return summarize_sleep_report(
+            report, sleep_target_seconds=self._sleep_target_seconds
+        ).get(self._key)
 
 
 def _build_sleep_report_sensors(
     coordinator: SleepReportUpdateManager,
     device_id: str,
     device_info: DeviceInfo,
+    *,
+    sleep_target_seconds: float,
 ) -> list[SleepReportSensor]:
-    """Build all aggregate sensors backed by the public report schema."""
+    """Build direct and derived sensors backed by public report data."""
     definitions: list[dict[str, Any]] = [
         {
             "key": "date",
@@ -464,12 +498,207 @@ def _build_sleep_report_sensors(
             "icon": "mdi:chart-timeline-variant",
         }
     )
+    definitions.extend(
+        [
+            {
+                "key": "sleep_efficiency_percent",
+                "label": "Sleep Efficiency",
+                "unit": PERCENTAGE,
+                "state_class": SensorStateClass.MEASUREMENT,
+                "icon": "mdi:percent-circle-outline",
+            },
+            {
+                "key": "wake_after_sleep_onset",
+                "label": "Wake After Sleep Onset",
+                "device_class": SensorDeviceClass.DURATION,
+                "unit": UnitOfTime.SECONDS,
+                "state_class": SensorStateClass.MEASUREMENT,
+            },
+            {
+                "key": "restorative_sleep_duration",
+                "label": "Restorative Sleep Duration",
+                "device_class": SensorDeviceClass.DURATION,
+                "unit": UnitOfTime.SECONDS,
+                "state_class": SensorStateClass.MEASUREMENT,
+                "icon": "mdi:brain",
+            },
+            {
+                "key": "sleep_debt",
+                "label": "Sleep Debt",
+                "device_class": SensorDeviceClass.DURATION,
+                "unit": UnitOfTime.SECONDS,
+                "state_class": SensorStateClass.MEASUREMENT,
+                "icon": "mdi:bed-clock",
+            },
+            {
+                "key": "sleep_goal_percent",
+                "label": "Sleep Goal",
+                "unit": PERCENTAGE,
+                "state_class": SensorStateClass.MEASUREMENT,
+                "icon": "mdi:target",
+            },
+            {
+                "key": "awakening_count",
+                "label": "Awakenings",
+                "state_class": SensorStateClass.MEASUREMENT,
+                "icon": "mdi:weather-sunset-up",
+            },
+            {
+                "key": "longest_uninterrupted_sleep_duration",
+                "label": "Longest Uninterrupted Sleep",
+                "device_class": SensorDeviceClass.DURATION,
+                "unit": UnitOfTime.SECONDS,
+                "state_class": SensorStateClass.MEASUREMENT,
+                "icon": "mdi:sleep",
+            },
+            {
+                "key": "main_enter_bed_time",
+                "label": "Main Sleep Entered Bed",
+                "device_class": SensorDeviceClass.TIMESTAMP,
+            },
+            {
+                "key": "main_exit_bed_time",
+                "label": "Main Sleep Exited Bed",
+                "device_class": SensorDeviceClass.TIMESTAMP,
+            },
+            {
+                "key": "sleep_midpoint",
+                "label": "Sleep Midpoint",
+                "device_class": SensorDeviceClass.TIMESTAMP,
+                "icon": "mdi:clock-time-four-outline",
+            },
+            {
+                "key": "nap_count",
+                "label": "Additional Sleep Sessions",
+                "state_class": SensorStateClass.MEASUREMENT,
+                "icon": "mdi:bed-clock",
+            },
+            {
+                "key": "nap_sleep_duration",
+                "label": "Additional Sleep Duration",
+                "device_class": SensorDeviceClass.DURATION,
+                "unit": UnitOfTime.SECONDS,
+                "state_class": SensorStateClass.MEASUREMENT,
+                "icon": "mdi:bed-clock",
+            },
+        ]
+    )
+    for key, label in (
+        ("awake_percent", "Awake"),
+        ("light_sleep_percent", "Light Sleep"),
+        ("rem_sleep_percent", "REM Sleep"),
+        ("deep_sleep_percent", "Deep Sleep"),
+        ("restorative_sleep_percent", "Restorative Sleep"),
+    ):
+        definitions.append(
+            {
+                "key": key,
+                "label": f"{label} Percentage",
+                "unit": PERCENTAGE,
+                "state_class": SensorStateClass.MEASUREMENT,
+                "icon": "mdi:chart-donut",
+            }
+        )
+
+    history_definitions: list[dict[str, Any]] = []
+    for days in (7, 30):
+        suffix = f"_{days}d"
+        history_definitions.extend(
+            [
+                {
+                    "key": f"tracked_nights{suffix}",
+                    "label": f"Tracked Nights {days} Day",
+                    "state_class": SensorStateClass.MEASUREMENT,
+                    "icon": "mdi:calendar-check",
+                },
+                {
+                    "key": f"average_sleep_score_percent{suffix}",
+                    "label": f"Average Sleep Score {days} Day",
+                    "unit": PERCENTAGE,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                    "icon": "mdi:sleep",
+                },
+                {
+                    "key": f"average_total_sleep_duration{suffix}",
+                    "label": f"Average Sleep Duration {days} Day",
+                    "device_class": SensorDeviceClass.DURATION,
+                    "unit": UnitOfTime.SECONDS,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+                {
+                    "key": f"average_sleep_efficiency_percent{suffix}",
+                    "label": f"Average Sleep Efficiency {days} Day",
+                    "unit": PERCENTAGE,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+                {
+                    "key": f"average_sleep_latency{suffix}",
+                    "label": f"Average Sleep Latency {days} Day",
+                    "device_class": SensorDeviceClass.DURATION,
+                    "unit": UnitOfTime.SECONDS,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+                {
+                    "key": f"average_deep_sleep_percent{suffix}",
+                    "label": f"Average Deep Sleep {days} Day",
+                    "unit": PERCENTAGE,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+                {
+                    "key": f"average_rem_sleep_percent{suffix}",
+                    "label": f"Average REM Sleep {days} Day",
+                    "unit": PERCENTAGE,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+                {
+                    "key": f"average_awakening_count{suffix}",
+                    "label": f"Average Awakenings {days} Day",
+                    "state_class": SensorStateClass.MEASUREMENT,
+                    "icon": "mdi:weather-sunset-up",
+                },
+                {
+                    "key": f"cumulative_sleep_debt{suffix}",
+                    "label": f"Cumulative Sleep Debt {days} Day",
+                    "device_class": SensorDeviceClass.DURATION,
+                    "unit": UnitOfTime.SECONDS,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                    "icon": "mdi:bed-clock",
+                },
+                {
+                    "key": f"bedtime_consistency{suffix}",
+                    "label": f"Bedtime Consistency {days} Day",
+                    "device_class": SensorDeviceClass.DURATION,
+                    "unit": UnitOfTime.MINUTES,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                    "icon": "mdi:clock-check-outline",
+                },
+                {
+                    "key": f"wake_time_consistency{suffix}",
+                    "label": f"Wake Time Consistency {days} Day",
+                    "device_class": SensorDeviceClass.DURATION,
+                    "unit": UnitOfTime.MINUTES,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                    "icon": "mdi:clock-check-outline",
+                },
+            ]
+        )
     return [
         SleepReportSensor(
             coordinator,
             device_id,
             device_info,
+            sleep_target_seconds=sleep_target_seconds,
             **definition,
         )
         for definition in definitions
+    ] + [
+        SleepReportSensor(
+            coordinator,
+            device_id,
+            device_info,
+            scope="history",
+            sleep_target_seconds=sleep_target_seconds,
+            **definition,
+        )
+        for definition in history_definitions
     ]

--- a/custom_components/sleepme_thermostat/services.yaml
+++ b/custom_components/sleepme_thermostat/services.yaml
@@ -1,0 +1,24 @@
+get_sleep_reports:
+  fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: sleepme_thermostat
+    start_date:
+      required: false
+      selector:
+        date:
+    days_back:
+      required: false
+      default: 6
+      selector:
+        number:
+          min: 0
+          max: 6
+          step: 1
+          mode: box
+    time_zone:
+      required: false
+      selector:
+        text:

--- a/custom_components/sleepme_thermostat/sleep_reports.py
+++ b/custom_components/sleepme_thermostat/sleep_reports.py
@@ -23,6 +23,7 @@ DURATION_FIELDS = (
 )
 
 SLEEP_STAGES = frozenset({"LIGHT_SLEEP", "REM_SLEEP", "DEEP_SLEEP"})
+SECONDS_PER_MINUTE = 60
 SECONDS_PER_DAY = 24 * 60 * 60
 
 
@@ -55,8 +56,13 @@ def summarize_sleep_report(
         ),
     }
 
+    # Sleepme's public report payload expresses every duration and hypnogram
+    # offset in minutes. Normalize once at the boundary so HA duration entities,
+    # history, goal/debt calculations, and automations consistently use seconds.
     for field in DURATION_FIELDS:
-        summary[field] = sum(_number(session.get(field)) for session in sessions)
+        summary[field] = sum(
+            _minutes_to_seconds(session.get(field)) for session in sessions
+        )
 
     enter_times = _session_datetimes(sessions, "enter_bed_time")
     exit_times = _session_datetimes(sessions, "exit_bed_time")
@@ -119,7 +125,7 @@ def summarize_sleep_report(
             # the main sleep; all additional sessions are exposed as nap metrics.
             "nap_count": len(supplemental_sessions),
             "nap_sleep_duration": sum(
-                _number(session.get("total_sleep_duration"))
+                _minutes_to_seconds(session.get("total_sleep_duration"))
                 for session in supplemental_sessions
             ),
         }
@@ -258,8 +264,8 @@ def _hypnogram_metrics(sessions: list[dict[str, Any]]) -> tuple[int, int | float
 
         for segment in segments:
             stage = segment["stage"]
-            start = _number(segment["start"])
-            end = _number(segment["end"])
+            start = _minutes_to_seconds(segment["start"])
+            end = _minutes_to_seconds(segment["end"])
             if end < start:
                 previous_stage = stage
                 run_start = run_end = None
@@ -345,6 +351,11 @@ def _optional_number(value: Any) -> int | float | None:
 def _number(value: Any) -> int | float:
     """Return numeric API values while treating absent/invalid values as zero."""
     return _optional_number(value) or 0
+
+
+def _minutes_to_seconds(value: Any) -> int | float:
+    """Normalize a numeric public-API minute value to seconds."""
+    return _number(value) * SECONDS_PER_MINUTE
 
 
 def _parse_datetime(value: Any) -> datetime | None:

--- a/custom_components/sleepme_thermostat/sleep_reports.py
+++ b/custom_components/sleepme_thermostat/sleep_reports.py
@@ -1,11 +1,15 @@
-"""Helpers for selecting and summarizing Sleepme sleep reports."""
+"""Select, aggregate, and derive metrics from Sleepme sleep reports."""
 
 from __future__ import annotations
 
-from datetime import date, datetime
+import math
+from collections.abc import Iterable
+from datetime import date, datetime, timedelta
 from typing import Any
 
 from homeassistant.util import dt as dt_util
+
+from .const import DEFAULT_SLEEP_TARGET_HOURS
 
 DURATION_FIELDS = (
     "total_session_duration",
@@ -18,30 +22,31 @@ DURATION_FIELDS = (
     "sleep_latency",
 )
 
+SLEEP_STAGES = frozenset({"LIGHT_SLEEP", "REM_SLEEP", "DEEP_SLEEP"})
+SECONDS_PER_DAY = 24 * 60 * 60
+
 
 def latest_sleep_report(reports: list[dict[str, Any]]) -> dict[str, Any] | None:
-    """Return the newest report containing at least one completed session."""
-    candidates = [
-        report
-        for report in reports
-        if isinstance(report.get("date"), str)
-        and isinstance(report.get("sessions"), list)
-        and report["sessions"]
-    ]
-    return max(candidates, key=lambda report: report["date"], default=None)
+    """Return the newest valid report containing a completed session."""
+    candidates = _dated_completed_reports(reports)
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: item[0])[1]
 
 
-def summarize_sleep_report(report: dict[str, Any] | None) -> dict[str, Any]:
-    """Aggregate all sessions in one daily report for entity-friendly states."""
+def summarize_sleep_report(
+    report: dict[str, Any] | None,
+    *,
+    sleep_target_seconds: float = DEFAULT_SLEEP_TARGET_HOURS * 3600,
+) -> dict[str, Any]:
+    """Aggregate sessions and derive recorder-friendly metrics for one day."""
     if report is None:
         return {}
 
-    sessions = [
-        session for session in report.get("sessions", []) if isinstance(session, dict)
-    ]
+    sessions = _sessions(report)
     summary: dict[str, Any] = {
         "date": _parse_date(report.get("date")),
-        "sleep_score_percent": report.get("sleep_score_percent"),
+        "sleep_score_percent": _optional_number(report.get("sleep_score_percent")),
         "session_count": len(sessions),
         "hypnogram_segment_count": sum(
             _number(session.get("hypnogram", {}).get("raw_hypnogram_segment_count"))
@@ -53,26 +58,293 @@ def summarize_sleep_report(report: dict[str, Any] | None) -> dict[str, Any]:
     for field in DURATION_FIELDS:
         summary[field] = sum(_number(session.get(field)) for session in sessions)
 
-    enter_times = [
-        parsed
-        for session in sessions
-        if (parsed := _parse_datetime(session.get("enter_bed_time"))) is not None
-    ]
-    exit_times = [
-        parsed
-        for session in sessions
-        if (parsed := _parse_datetime(session.get("exit_bed_time"))) is not None
-    ]
+    enter_times = _session_datetimes(sessions, "enter_bed_time")
+    exit_times = _session_datetimes(sessions, "exit_bed_time")
     summary["enter_bed_time"] = min(enter_times, default=None)
     summary["exit_bed_time"] = max(exit_times, default=None)
+
+    total_sleep = summary["total_sleep_duration"]
+    in_bed = summary["in_bed_duration"]
+    awake = summary["awake_duration"]
+    latency = summary["sleep_latency"]
+    rem_sleep = summary["rem_sleep_duration"]
+    deep_sleep = summary["deep_sleep_duration"]
+    restorative_sleep = rem_sleep + deep_sleep
+
+    summary.update(
+        {
+            "sleep_efficiency_percent": _percentage(total_sleep, in_bed),
+            "wake_after_sleep_onset": max(awake - latency, 0),
+            "awake_percent": _percentage(awake, in_bed),
+            "light_sleep_percent": _percentage(
+                summary["light_sleep_duration"], total_sleep
+            ),
+            "rem_sleep_percent": _percentage(rem_sleep, total_sleep),
+            "deep_sleep_percent": _percentage(deep_sleep, total_sleep),
+            "restorative_sleep_duration": restorative_sleep,
+            "restorative_sleep_percent": _percentage(restorative_sleep, total_sleep),
+            "sleep_debt": max(sleep_target_seconds - total_sleep, 0),
+            "sleep_goal_percent": _percentage(total_sleep, sleep_target_seconds),
+        }
+    )
+
+    awakening_count, longest_sleep = _hypnogram_metrics(sessions)
+    summary["awakening_count"] = awakening_count
+    summary["longest_uninterrupted_sleep_duration"] = longest_sleep
+
+    main_session = _main_session(sessions)
+    if main_session is None:
+        summary.update(
+            {
+                "main_enter_bed_time": None,
+                "main_exit_bed_time": None,
+                "sleep_midpoint": None,
+                "nap_count": 0,
+                "nap_sleep_duration": 0,
+            }
+        )
+        return summary
+
+    main_enter = _parse_datetime(main_session.get("enter_bed_time"))
+    main_exit = _parse_datetime(main_session.get("exit_bed_time"))
+    supplemental_sessions = [
+        session for session in sessions if session is not main_session
+    ]
+    summary.update(
+        {
+            "main_enter_bed_time": main_enter,
+            "main_exit_bed_time": main_exit,
+            "sleep_midpoint": _midpoint(main_enter, main_exit),
+            # The API does not label naps. The longest sleep session is treated as
+            # the main sleep; all additional sessions are exposed as nap metrics.
+            "nap_count": len(supplemental_sessions),
+            "nap_sleep_duration": sum(
+                _number(session.get("total_sleep_duration"))
+                for session in supplemental_sessions
+            ),
+        }
+    )
     return summary
+
+
+def summarize_sleep_history(
+    reports: list[dict[str, Any]],
+    *,
+    sleep_target_seconds: float = DEFAULT_SLEEP_TARGET_HOURS * 3600,
+) -> dict[str, Any]:
+    """Return seven- and thirty-day trends ending at the newest report date."""
+    dated_reports = _dated_completed_reports(reports)
+    all_dates = [
+        parsed
+        for report in reports
+        if (parsed := _parse_date(report.get("date"))) is not None
+    ]
+    if not all_dates:
+        return {}
+
+    end_date = max(all_dates)
+    result: dict[str, Any] = {}
+    for window_days in (7, 30):
+        cutoff = end_date - timedelta(days=window_days - 1)
+        summaries = [
+            summarize_sleep_report(report, sleep_target_seconds=sleep_target_seconds)
+            for report_date, report in dated_reports
+            if cutoff <= report_date <= end_date
+        ]
+        suffix = f"_{window_days}d"
+        result[f"tracked_nights{suffix}"] = len(summaries)
+        result[f"average_sleep_score_percent{suffix}"] = _average(
+            summary.get("sleep_score_percent") for summary in summaries
+        )
+        result[f"average_total_sleep_duration{suffix}"] = _average(
+            summary.get("total_sleep_duration") for summary in summaries
+        )
+        result[f"average_sleep_efficiency_percent{suffix}"] = _average(
+            summary.get("sleep_efficiency_percent") for summary in summaries
+        )
+        result[f"average_sleep_latency{suffix}"] = _average(
+            summary.get("sleep_latency") for summary in summaries
+        )
+        result[f"average_deep_sleep_percent{suffix}"] = _average(
+            summary.get("deep_sleep_percent") for summary in summaries
+        )
+        result[f"average_rem_sleep_percent{suffix}"] = _average(
+            summary.get("rem_sleep_percent") for summary in summaries
+        )
+        result[f"average_awakening_count{suffix}"] = _average(
+            summary.get("awakening_count") for summary in summaries
+        )
+        result[f"cumulative_sleep_debt{suffix}"] = sum(
+            _number(summary.get("sleep_debt")) for summary in summaries
+        )
+        result[f"bedtime_consistency{suffix}"] = _clock_consistency_minutes(
+            summary.get("main_enter_bed_time") for summary in summaries
+        )
+        result[f"wake_time_consistency{suffix}"] = _clock_consistency_minutes(
+            summary.get("main_exit_bed_time") for summary in summaries
+        )
+
+    return result
+
+
+def _dated_completed_reports(
+    reports: list[dict[str, Any]],
+) -> list[tuple[date, dict[str, Any]]]:
+    """Return reports with a valid date and at least one dictionary session."""
+    dated: list[tuple[date, dict[str, Any]]] = []
+    for report in reports:
+        report_date = _parse_date(report.get("date"))
+        if report_date is not None and _sessions(report):
+            dated.append((report_date, report))
+    return dated
+
+
+def _sessions(report: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return only dictionary sessions from a report."""
+    raw_sessions = report.get("sessions", [])
+    if not isinstance(raw_sessions, list):
+        return []
+    return [session for session in raw_sessions if isinstance(session, dict)]
+
+
+def _main_session(sessions: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Select the longest-sleep session as the main daily sleep."""
+    return max(
+        sessions,
+        key=lambda session: (
+            _number(session.get("total_sleep_duration")),
+            _number(session.get("total_session_duration")),
+        ),
+        default=None,
+    )
+
+
+def _session_datetimes(sessions: list[dict[str, Any]], key: str) -> list[datetime]:
+    """Parse one timestamp field from every valid session."""
+    return [
+        parsed
+        for session in sessions
+        if (parsed := _parse_datetime(session.get(key))) is not None
+    ]
+
+
+def _hypnogram_metrics(sessions: list[dict[str, Any]]) -> tuple[int, int | float]:
+    """Count sleep-to-awake transitions and the longest continuous sleep run."""
+    awakenings = 0
+    longest_sleep: int | float = 0
+
+    for session in sessions:
+        hypnogram = session.get("hypnogram")
+        if not isinstance(hypnogram, dict):
+            continue
+        raw_segments = hypnogram.get("segments")
+        if not isinstance(raw_segments, list):
+            continue
+
+        segments = sorted(
+            (
+                segment
+                for segment in raw_segments
+                if isinstance(segment, dict)
+                and _optional_number(segment.get("start")) is not None
+                and _optional_number(segment.get("end")) is not None
+                and isinstance(segment.get("stage"), str)
+            ),
+            key=lambda segment: _number(segment["start"]),
+        )
+        previous_stage: str | None = None
+        run_start: int | float | None = None
+        run_end: int | float | None = None
+
+        for segment in segments:
+            stage = segment["stage"]
+            start = _number(segment["start"])
+            end = _number(segment["end"])
+            if end < start:
+                previous_stage = stage
+                run_start = run_end = None
+                continue
+
+            if stage == "AWAKE" and previous_stage in SLEEP_STAGES:
+                awakenings += 1
+
+            if stage in SLEEP_STAGES:
+                if run_start is None or run_end is None or start != run_end:
+                    run_start = start
+                run_end = end
+                longest_sleep = max(longest_sleep, run_end - run_start)
+            else:
+                run_start = run_end = None
+
+            previous_stage = stage
+
+    return awakenings, longest_sleep
+
+
+def _percentage(numerator: int | float, denominator: int | float) -> float | None:
+    """Return a one-decimal percentage, or None when undefined."""
+    if denominator <= 0:
+        return None
+    return round(numerator / denominator * 100, 1)
+
+
+def _average(values: Iterable[Any]) -> float | None:
+    """Average valid numbers with one-decimal stability."""
+    numbers = [
+        number for value in values if (number := _optional_number(value)) is not None
+    ]
+    if not numbers:
+        return None
+    return round(sum(numbers) / len(numbers), 1)
+
+
+def _clock_consistency_minutes(values: Iterable[Any]) -> float | None:
+    """Return mean circular clock-time deviation in minutes."""
+    clock_seconds = [
+        value.hour * 3600 + value.minute * 60 + value.second
+        for value in values
+        if isinstance(value, datetime)
+    ]
+    if len(clock_seconds) < 2:
+        return None
+
+    angles = [seconds / SECONDS_PER_DAY * math.tau for seconds in clock_seconds]
+    mean_angle = math.atan2(
+        sum(math.sin(angle) for angle in angles),
+        sum(math.cos(angle) for angle in angles),
+    )
+    if mean_angle < 0:
+        mean_angle += math.tau
+    mean_seconds = mean_angle / math.tau * SECONDS_PER_DAY
+    deviations = [
+        min(
+            abs(seconds - mean_seconds),
+            SECONDS_PER_DAY - abs(seconds - mean_seconds),
+        )
+        for seconds in clock_seconds
+    ]
+    return round(sum(deviations) / len(deviations) / 60, 1)
+
+
+def _midpoint(start: datetime | None, end: datetime | None) -> datetime | None:
+    """Return the midpoint of a valid session interval."""
+    if start is None or end is None or end < start:
+        return None
+    return start + (end - start) / 2
+
+
+def _optional_number(value: Any) -> int | float | None:
+    """Return a numeric API value, rejecting booleans and other shapes."""
+    return (
+        value
+        if isinstance(value, int | float) and not isinstance(value, bool)
+        else None
+    )
 
 
 def _number(value: Any) -> int | float:
     """Return numeric API values while treating absent/invalid values as zero."""
-    return (
-        value if isinstance(value, int | float) and not isinstance(value, bool) else 0
-    )
+    return _optional_number(value) or 0
 
 
 def _parse_datetime(value: Any) -> datetime | None:

--- a/custom_components/sleepme_thermostat/sleep_reports.py
+++ b/custom_components/sleepme_thermostat/sleep_reports.py
@@ -1,0 +1,90 @@
+"""Helpers for selecting and summarizing Sleepme sleep reports."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
+from homeassistant.util import dt as dt_util
+
+DURATION_FIELDS = (
+    "total_session_duration",
+    "in_bed_duration",
+    "total_sleep_duration",
+    "awake_duration",
+    "light_sleep_duration",
+    "rem_sleep_duration",
+    "deep_sleep_duration",
+    "sleep_latency",
+)
+
+
+def latest_sleep_report(reports: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the newest report containing at least one completed session."""
+    candidates = [
+        report
+        for report in reports
+        if isinstance(report.get("date"), str)
+        and isinstance(report.get("sessions"), list)
+        and report["sessions"]
+    ]
+    return max(candidates, key=lambda report: report["date"], default=None)
+
+
+def summarize_sleep_report(report: dict[str, Any] | None) -> dict[str, Any]:
+    """Aggregate all sessions in one daily report for entity-friendly states."""
+    if report is None:
+        return {}
+
+    sessions = [
+        session for session in report.get("sessions", []) if isinstance(session, dict)
+    ]
+    summary: dict[str, Any] = {
+        "date": _parse_date(report.get("date")),
+        "sleep_score_percent": report.get("sleep_score_percent"),
+        "session_count": len(sessions),
+        "hypnogram_segment_count": sum(
+            _number(session.get("hypnogram", {}).get("raw_hypnogram_segment_count"))
+            for session in sessions
+            if isinstance(session.get("hypnogram"), dict)
+        ),
+    }
+
+    for field in DURATION_FIELDS:
+        summary[field] = sum(_number(session.get(field)) for session in sessions)
+
+    enter_times = [
+        parsed
+        for session in sessions
+        if (parsed := _parse_datetime(session.get("enter_bed_time"))) is not None
+    ]
+    exit_times = [
+        parsed
+        for session in sessions
+        if (parsed := _parse_datetime(session.get("exit_bed_time"))) is not None
+    ]
+    summary["enter_bed_time"] = min(enter_times, default=None)
+    summary["exit_bed_time"] = max(exit_times, default=None)
+    return summary
+
+
+def _number(value: Any) -> int | float:
+    """Return numeric API values while treating absent/invalid values as zero."""
+    return (
+        value if isinstance(value, int | float) and not isinstance(value, bool) else 0
+    )
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    """Parse an RFC3339 timestamp returned by Sleepme."""
+    return dt_util.parse_datetime(value) if isinstance(value, str) else None
+
+
+def _parse_date(value: Any) -> date | None:
+    """Parse an ISO calendar date returned by Sleepme."""
+    if not isinstance(value, str):
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None

--- a/custom_components/sleepme_thermostat/sleepme.py
+++ b/custom_components/sleepme_thermostat/sleepme.py
@@ -7,6 +7,8 @@ climate command path) translate them into HA-framework exceptions.
 
 from __future__ import annotations
 
+from datetime import date
+
 from homeassistant.core import HomeAssistant
 
 from .helpers import round_half_up
@@ -55,3 +57,30 @@ class SleepMeClient:
         if not isinstance(response, dict):
             raise ValueError(f"unexpected response for device status: {response!r}")
         return response
+
+    async def get_sleep_reports(
+        self,
+        *,
+        start_date: date,
+        days_back: int,
+        time_zone: str,
+        retries: int = 0,
+    ) -> list[dict]:
+        """Return account-scoped sleep reports ending on ``start_date``."""
+        response = await self.api.api_request(
+            "GET",
+            "sleep-reports",
+            params={
+                "start_date": start_date.isoformat(),
+                "days_back": days_back,
+                "time_zone": time_zone,
+            },
+            retries=retries,
+        )
+        if not isinstance(response, dict) or not isinstance(
+            response.get("reports"), list
+        ):
+            raise ValueError(f"unexpected response for sleep reports: {response!r}")
+        if not all(isinstance(report, dict) for report in response["reports"]):
+            raise ValueError(f"unexpected response for sleep reports: {response!r}")
+        return response["reports"]

--- a/custom_components/sleepme_thermostat/sleepme_api.py
+++ b/custom_components/sleepme_thermostat/sleepme_api.py
@@ -24,6 +24,7 @@ import asyncio
 import logging
 import time
 from collections import deque
+from collections.abc import Mapping
 from email.utils import parsedate_to_datetime
 from typing import Any
 from weakref import WeakValueDictionary
@@ -120,6 +121,7 @@ class SleepMeAPI:
         endpoint: str,
         *,
         data: dict | None = None,
+        params: Mapping[str, str | int] | None = None,
         retries: int = DEFAULT_RETRIES,
     ) -> Any:
         """Send one request with retry-on-transient-error.
@@ -134,7 +136,9 @@ class SleepMeAPI:
         while True:
             await self._enforce_local_rate_limit(method, endpoint)
             try:
-                return await self._perform_request(method, endpoint, data=data)
+                return await self._perform_request(
+                    method, endpoint, data=data, params=params
+                )
             except httpx.HTTPStatusError as err:
                 status = err.response.status_code
                 if status in (401, 403):
@@ -250,6 +254,7 @@ class SleepMeAPI:
         endpoint: str,
         *,
         data: dict | None,
+        params: Mapping[str, str | int] | None,
     ) -> Any:
         headers = {"Authorization": f"Bearer {self.token}"}
         _LOGGER.debug("%s %s/%s data=%s", method, self.api_url, endpoint, data)
@@ -258,6 +263,7 @@ class SleepMeAPI:
             f"{self.api_url}/{endpoint}",
             headers=headers,
             json=data,
+            params=params,
         )
         response.raise_for_status()
         return response.json()

--- a/custom_components/sleepme_thermostat/strings.json
+++ b/custom_components/sleepme_thermostat/strings.json
@@ -1,9 +1,9 @@
 {
-  "title": "SleepMe Dock Pro",
+  "title": "SleepMe",
   "config": {
     "step": {
       "user": {
-        "title": "Add SleepMe Dock Pro",
+        "title": "Add SleepMe device",
         "description": "Please enter your API token to proceed.",
         "data": {
           "api_token": "API Token"
@@ -13,8 +13,8 @@
         }
       },
       "select_device": {
-        "title": "Select Dock Pro Device",
-        "description": "Select the Dock Pro device you want to add.",
+        "title": "Select SleepMe device",
+        "description": "Select the Dock Pro, Chilipad, or Sleep Tracker you want to add.",
         "data": {
           "device_id": "Bed / Device"
         },
@@ -23,7 +23,7 @@
         }
       },
       "reauth_confirm": {
-        "title": "Re-authenticate SleepMe Dock Pro",
+        "title": "Re-authenticate SleepMe",
         "description": "Your SleepMe API token is no longer valid. Enter a new token to reconnect.",
         "data": {
           "api_token": "API Token"
@@ -48,7 +48,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "SleepMe Dock Pro options",
+        "title": "SleepMe device options",
         "description": "Adjust how often Home Assistant polls the SleepMe API for this device. Lower values feel more responsive but consume more of your per-minute API budget.",
         "data": {
           "scan_interval": "Poll interval (seconds)"
@@ -57,6 +57,30 @@
     },
     "error": {
       "invalid_scan_interval": "Poll interval must be between 10 and 300 seconds."
+    }
+  },
+  "services": {
+    "get_sleep_reports": {
+      "name": "Get sleep reports",
+      "description": "Fetch the complete raw Sleepme sleep-report payload for an account. The response includes sessions and hypnogram segments and is not stored in Home Assistant's recorder.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The loaded SleepMe configuration entry whose API token should be used."
+        },
+        "start_date": {
+          "name": "End date",
+          "description": "The final report date to request. Defaults to today in the selected time zone."
+        },
+        "days_back": {
+          "name": "Days back",
+          "description": "The number of preceding days to include, from zero through six."
+        },
+        "time_zone": {
+          "name": "Time zone",
+          "description": "An IANA time-zone name. Defaults to Home Assistant's configured time zone."
+        }
+      }
     }
   }
 }

--- a/custom_components/sleepme_thermostat/strings.json
+++ b/custom_components/sleepme_thermostat/strings.json
@@ -45,18 +45,77 @@
       "reauth_successful": "Re-authentication was successful."
     }
   },
+  "entity": {
+    "sensor": {
+      "date": { "name": "Last Sleep Report" },
+      "sleep_score_percent": { "name": "Sleep Score" },
+      "session_count": { "name": "Sleep Sessions" },
+      "enter_bed_time": { "name": "Entered Bed" },
+      "exit_bed_time": { "name": "Exited Bed" },
+      "total_session_duration": { "name": "Total Session Duration" },
+      "in_bed_duration": { "name": "In-bed Duration" },
+      "total_sleep_duration": { "name": "Total Sleep Duration" },
+      "awake_duration": { "name": "Awake Duration" },
+      "light_sleep_duration": { "name": "Light Sleep Duration" },
+      "rem_sleep_duration": { "name": "REM Sleep Duration" },
+      "deep_sleep_duration": { "name": "Deep Sleep Duration" },
+      "sleep_latency": { "name": "Sleep Latency" },
+      "hypnogram_segment_count": { "name": "Hypnogram Segments" },
+      "sleep_efficiency_percent": { "name": "Sleep Efficiency" },
+      "wake_after_sleep_onset": { "name": "Wake After Sleep Onset" },
+      "restorative_sleep_duration": { "name": "Restorative Sleep Duration" },
+      "sleep_debt": { "name": "Sleep Debt" },
+      "sleep_goal_percent": { "name": "Sleep Goal" },
+      "awakening_count": { "name": "Awakenings" },
+      "longest_uninterrupted_sleep_duration": { "name": "Longest Uninterrupted Sleep" },
+      "main_enter_bed_time": { "name": "Main Sleep Entered Bed" },
+      "main_exit_bed_time": { "name": "Main Sleep Exited Bed" },
+      "sleep_midpoint": { "name": "Sleep Midpoint" },
+      "nap_count": { "name": "Additional Sleep Sessions" },
+      "nap_sleep_duration": { "name": "Additional Sleep Duration" },
+      "awake_percent": { "name": "Awake Percentage" },
+      "light_sleep_percent": { "name": "Light Sleep Percentage" },
+      "rem_sleep_percent": { "name": "REM Sleep Percentage" },
+      "deep_sleep_percent": { "name": "Deep Sleep Percentage" },
+      "restorative_sleep_percent": { "name": "Restorative Sleep Percentage" },
+      "tracked_nights_7d": { "name": "Tracked Nights 7 Day" },
+      "average_sleep_score_percent_7d": { "name": "Average Sleep Score 7 Day" },
+      "average_total_sleep_duration_7d": { "name": "Average Sleep Duration 7 Day" },
+      "average_sleep_efficiency_percent_7d": { "name": "Average Sleep Efficiency 7 Day" },
+      "average_sleep_latency_7d": { "name": "Average Sleep Latency 7 Day" },
+      "average_deep_sleep_percent_7d": { "name": "Average Deep Sleep 7 Day" },
+      "average_rem_sleep_percent_7d": { "name": "Average REM Sleep 7 Day" },
+      "average_awakening_count_7d": { "name": "Average Awakenings 7 Day" },
+      "cumulative_sleep_debt_7d": { "name": "Cumulative Sleep Debt 7 Day" },
+      "bedtime_consistency_7d": { "name": "Bedtime Consistency 7 Day" },
+      "wake_time_consistency_7d": { "name": "Wake Time Consistency 7 Day" },
+      "tracked_nights_30d": { "name": "Tracked Nights 30 Day" },
+      "average_sleep_score_percent_30d": { "name": "Average Sleep Score 30 Day" },
+      "average_total_sleep_duration_30d": { "name": "Average Sleep Duration 30 Day" },
+      "average_sleep_efficiency_percent_30d": { "name": "Average Sleep Efficiency 30 Day" },
+      "average_sleep_latency_30d": { "name": "Average Sleep Latency 30 Day" },
+      "average_deep_sleep_percent_30d": { "name": "Average Deep Sleep 30 Day" },
+      "average_rem_sleep_percent_30d": { "name": "Average REM Sleep 30 Day" },
+      "average_awakening_count_30d": { "name": "Average Awakenings 30 Day" },
+      "cumulative_sleep_debt_30d": { "name": "Cumulative Sleep Debt 30 Day" },
+      "bedtime_consistency_30d": { "name": "Bedtime Consistency 30 Day" },
+      "wake_time_consistency_30d": { "name": "Wake Time Consistency 30 Day" }
+    }
+  },
   "options": {
     "step": {
       "init": {
         "title": "SleepMe device options",
-        "description": "Adjust how often Home Assistant polls the SleepMe API for this device. Lower values feel more responsive but consume more of your per-minute API budget.",
+        "description": "Adjust how often Home Assistant polls the SleepMe API. Sleep Tracker entries can also set the personal nightly goal used by Home Assistant's derived sleep-goal and sleep-debt sensors.",
         "data": {
-          "scan_interval": "Poll interval (seconds)"
+          "scan_interval": "Poll interval (seconds)",
+          "sleep_target_hours": "Nightly sleep target (hours)"
         }
       }
     },
     "error": {
-      "invalid_scan_interval": "Poll interval must be between 10 and 300 seconds."
+      "invalid_scan_interval": "Poll interval must be between 10 and 300 seconds.",
+      "invalid_sleep_target": "Nightly sleep target must be between 4 and 12 hours."
     }
   },
   "services": {

--- a/custom_components/sleepme_thermostat/translations/en.json
+++ b/custom_components/sleepme_thermostat/translations/en.json
@@ -1,9 +1,9 @@
 {
-  "title": "SleepMe Dock Pro",
+  "title": "SleepMe",
   "config": {
     "step": {
       "user": {
-        "title": "Add SleepMe Dock Pro",
+        "title": "Add SleepMe device",
         "description": "Please enter your API token to proceed.",
         "data": {
           "api_token": "API Token"
@@ -13,8 +13,8 @@
         }
       },
       "select_device": {
-        "title": "Select Dock Pro Device",
-        "description": "Select the Dock Pro device you want to add.",
+        "title": "Select SleepMe device",
+        "description": "Select the Dock Pro, Chilipad, or Sleep Tracker you want to add.",
         "data": {
           "device_id": "Bed / Device"
         },
@@ -23,7 +23,7 @@
         }
       },
       "reauth_confirm": {
-        "title": "Re-authenticate SleepMe Dock Pro",
+        "title": "Re-authenticate SleepMe",
         "description": "Your SleepMe API token is no longer valid. Enter a new token to reconnect.",
         "data": {
           "api_token": "API Token"
@@ -48,7 +48,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "SleepMe Dock Pro options",
+        "title": "SleepMe device options",
         "description": "Adjust how often Home Assistant polls the SleepMe API for this device. Lower values feel more responsive but consume more of your per-minute API budget.",
         "data": {
           "scan_interval": "Poll interval (seconds)"
@@ -57,6 +57,30 @@
     },
     "error": {
       "invalid_scan_interval": "Poll interval must be between 10 and 300 seconds."
+    }
+  },
+  "services": {
+    "get_sleep_reports": {
+      "name": "Get sleep reports",
+      "description": "Fetch the complete raw Sleepme sleep-report payload for an account. The response includes sessions and hypnogram segments and is not stored in Home Assistant's recorder.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The loaded SleepMe configuration entry whose API token should be used."
+        },
+        "start_date": {
+          "name": "End date",
+          "description": "The final report date to request. Defaults to today in the selected time zone."
+        },
+        "days_back": {
+          "name": "Days back",
+          "description": "The number of preceding days to include, from zero through six."
+        },
+        "time_zone": {
+          "name": "Time zone",
+          "description": "An IANA time-zone name. Defaults to Home Assistant's configured time zone."
+        }
+      }
     }
   }
 }

--- a/custom_components/sleepme_thermostat/translations/en.json
+++ b/custom_components/sleepme_thermostat/translations/en.json
@@ -45,18 +45,77 @@
       "reauth_successful": "Re-authentication was successful."
     }
   },
+  "entity": {
+    "sensor": {
+      "date": { "name": "Last Sleep Report" },
+      "sleep_score_percent": { "name": "Sleep Score" },
+      "session_count": { "name": "Sleep Sessions" },
+      "enter_bed_time": { "name": "Entered Bed" },
+      "exit_bed_time": { "name": "Exited Bed" },
+      "total_session_duration": { "name": "Total Session Duration" },
+      "in_bed_duration": { "name": "In-bed Duration" },
+      "total_sleep_duration": { "name": "Total Sleep Duration" },
+      "awake_duration": { "name": "Awake Duration" },
+      "light_sleep_duration": { "name": "Light Sleep Duration" },
+      "rem_sleep_duration": { "name": "REM Sleep Duration" },
+      "deep_sleep_duration": { "name": "Deep Sleep Duration" },
+      "sleep_latency": { "name": "Sleep Latency" },
+      "hypnogram_segment_count": { "name": "Hypnogram Segments" },
+      "sleep_efficiency_percent": { "name": "Sleep Efficiency" },
+      "wake_after_sleep_onset": { "name": "Wake After Sleep Onset" },
+      "restorative_sleep_duration": { "name": "Restorative Sleep Duration" },
+      "sleep_debt": { "name": "Sleep Debt" },
+      "sleep_goal_percent": { "name": "Sleep Goal" },
+      "awakening_count": { "name": "Awakenings" },
+      "longest_uninterrupted_sleep_duration": { "name": "Longest Uninterrupted Sleep" },
+      "main_enter_bed_time": { "name": "Main Sleep Entered Bed" },
+      "main_exit_bed_time": { "name": "Main Sleep Exited Bed" },
+      "sleep_midpoint": { "name": "Sleep Midpoint" },
+      "nap_count": { "name": "Additional Sleep Sessions" },
+      "nap_sleep_duration": { "name": "Additional Sleep Duration" },
+      "awake_percent": { "name": "Awake Percentage" },
+      "light_sleep_percent": { "name": "Light Sleep Percentage" },
+      "rem_sleep_percent": { "name": "REM Sleep Percentage" },
+      "deep_sleep_percent": { "name": "Deep Sleep Percentage" },
+      "restorative_sleep_percent": { "name": "Restorative Sleep Percentage" },
+      "tracked_nights_7d": { "name": "Tracked Nights 7 Day" },
+      "average_sleep_score_percent_7d": { "name": "Average Sleep Score 7 Day" },
+      "average_total_sleep_duration_7d": { "name": "Average Sleep Duration 7 Day" },
+      "average_sleep_efficiency_percent_7d": { "name": "Average Sleep Efficiency 7 Day" },
+      "average_sleep_latency_7d": { "name": "Average Sleep Latency 7 Day" },
+      "average_deep_sleep_percent_7d": { "name": "Average Deep Sleep 7 Day" },
+      "average_rem_sleep_percent_7d": { "name": "Average REM Sleep 7 Day" },
+      "average_awakening_count_7d": { "name": "Average Awakenings 7 Day" },
+      "cumulative_sleep_debt_7d": { "name": "Cumulative Sleep Debt 7 Day" },
+      "bedtime_consistency_7d": { "name": "Bedtime Consistency 7 Day" },
+      "wake_time_consistency_7d": { "name": "Wake Time Consistency 7 Day" },
+      "tracked_nights_30d": { "name": "Tracked Nights 30 Day" },
+      "average_sleep_score_percent_30d": { "name": "Average Sleep Score 30 Day" },
+      "average_total_sleep_duration_30d": { "name": "Average Sleep Duration 30 Day" },
+      "average_sleep_efficiency_percent_30d": { "name": "Average Sleep Efficiency 30 Day" },
+      "average_sleep_latency_30d": { "name": "Average Sleep Latency 30 Day" },
+      "average_deep_sleep_percent_30d": { "name": "Average Deep Sleep 30 Day" },
+      "average_rem_sleep_percent_30d": { "name": "Average REM Sleep 30 Day" },
+      "average_awakening_count_30d": { "name": "Average Awakenings 30 Day" },
+      "cumulative_sleep_debt_30d": { "name": "Cumulative Sleep Debt 30 Day" },
+      "bedtime_consistency_30d": { "name": "Bedtime Consistency 30 Day" },
+      "wake_time_consistency_30d": { "name": "Wake Time Consistency 30 Day" }
+    }
+  },
   "options": {
     "step": {
       "init": {
         "title": "SleepMe device options",
-        "description": "Adjust how often Home Assistant polls the SleepMe API for this device. Lower values feel more responsive but consume more of your per-minute API budget.",
+        "description": "Adjust how often Home Assistant polls the SleepMe API. Sleep Tracker entries can also set the personal nightly goal used by Home Assistant's derived sleep-goal and sleep-debt sensors.",
         "data": {
-          "scan_interval": "Poll interval (seconds)"
+          "scan_interval": "Poll interval (seconds)",
+          "sleep_target_hours": "Nightly sleep target (hours)"
         }
       }
     },
     "error": {
-      "invalid_scan_interval": "Poll interval must be between 10 and 300 seconds."
+      "invalid_scan_interval": "Poll interval must be between 10 and 300 seconds.",
+      "invalid_sleep_target": "Nightly sleep target must be between 4 and 12 hours."
     }
   },
   "services": {

--- a/custom_components/sleepme_thermostat/translations/es.json
+++ b/custom_components/sleepme_thermostat/translations/es.json
@@ -49,14 +49,16 @@
     "step": {
       "init": {
         "title": "Opciones del dispositivo SleepMe",
-        "description": "Ajusta con qué frecuencia Home Assistant consulta la API de SleepMe para este dispositivo. Valores más bajos son más reactivos pero consumen más de tu presupuesto de llamadas por minuto.",
+        "description": "Ajusta con qué frecuencia Home Assistant consulta la API de SleepMe. Para Sleep Tracker también puedes configurar el objetivo nocturno usado por los sensores derivados de objetivo y deuda de sueño.",
         "data": {
-          "scan_interval": "Intervalo de sondeo (segundos)"
+          "scan_interval": "Intervalo de sondeo (segundos)",
+          "sleep_target_hours": "Objetivo nocturno de sueño (horas)"
         }
       }
     },
     "error": {
-      "invalid_scan_interval": "El intervalo de sondeo debe estar entre 10 y 300 segundos."
+      "invalid_scan_interval": "El intervalo de sondeo debe estar entre 10 y 300 segundos.",
+      "invalid_sleep_target": "El objetivo nocturno debe estar entre 4 y 12 horas."
     }
   },
   "services": {

--- a/custom_components/sleepme_thermostat/translations/es.json
+++ b/custom_components/sleepme_thermostat/translations/es.json
@@ -1,9 +1,9 @@
 {
-  "title": "SleepMe Dock Pro",
+  "title": "SleepMe",
   "config": {
     "step": {
       "user": {
-        "title": "Configurar SleepMe Dock Pro",
+        "title": "Configurar dispositivo SleepMe",
         "description": "Por favor, ingrese su token de API.",
         "data": {
           "api_token": "Token de API"
@@ -14,7 +14,7 @@
       },
       "select_device": {
         "title": "Seleccionar Dispositivo",
-        "description": "Seleccione el dispositivo Dock Pro que desea configurar.",
+        "description": "Seleccione el Dock Pro, Chilipad o Sleep Tracker que desea configurar.",
         "data": {
           "device_id": "Cama / Dispositivo"
         },
@@ -23,7 +23,7 @@
         }
       },
       "reauth_confirm": {
-        "title": "Re-autenticar SleepMe Dock Pro",
+        "title": "Re-autenticar SleepMe",
         "description": "Su token de API de SleepMe ya no es válido. Ingrese un nuevo token para volver a conectarse.",
         "data": {
           "api_token": "Token de API"
@@ -48,7 +48,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "Opciones de SleepMe Dock Pro",
+        "title": "Opciones del dispositivo SleepMe",
         "description": "Ajusta con qué frecuencia Home Assistant consulta la API de SleepMe para este dispositivo. Valores más bajos son más reactivos pero consumen más de tu presupuesto de llamadas por minuto.",
         "data": {
           "scan_interval": "Intervalo de sondeo (segundos)"
@@ -57,6 +57,30 @@
     },
     "error": {
       "invalid_scan_interval": "El intervalo de sondeo debe estar entre 10 y 300 segundos."
+    }
+  },
+  "services": {
+    "get_sleep_reports": {
+      "name": "Obtener informes de sueño",
+      "description": "Obtiene la respuesta completa de los informes de sueño de Sleepme sin guardarla en el historial de Home Assistant.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Entrada de configuración",
+          "description": "La entrada de configuración de SleepMe cuyo token de API se utilizará."
+        },
+        "start_date": {
+          "name": "Fecha final",
+          "description": "La última fecha del informe que se solicitará."
+        },
+        "days_back": {
+          "name": "Días anteriores",
+          "description": "Número de días anteriores que se incluirán, de cero a seis."
+        },
+        "time_zone": {
+          "name": "Zona horaria",
+          "description": "Nombre de zona horaria IANA. De forma predeterminada se usa la zona de Home Assistant."
+        }
+      }
     }
   }
 }

--- a/custom_components/sleepme_thermostat/translations/hu.json
+++ b/custom_components/sleepme_thermostat/translations/hu.json
@@ -1,0 +1,145 @@
+{
+  "title": "SleepMe",
+  "config": {
+    "step": {
+      "user": {
+        "title": "SleepMe-eszköz hozzáadása",
+        "description": "A folytatáshoz add meg az API-tokenedet.",
+        "data": {
+          "api_token": "API-token"
+        },
+        "data_description": {
+          "api_token": "Add meg a SleepMe által biztosított API-tokent."
+        }
+      },
+      "select_device": {
+        "title": "SleepMe-eszköz kiválasztása",
+        "description": "Válaszd ki a hozzáadni kívánt Dock Pro, Chilipad vagy Sleep Tracker eszközt.",
+        "data": {
+          "device_id": "Ágy / eszköz"
+        },
+        "data_description": {
+          "device_id": "Az eszközt a SleepMe alkalmazásban megadott neve alapján válaszd ki."
+        }
+      },
+      "reauth_confirm": {
+        "title": "SleepMe újbóli hitelesítése",
+        "description": "A SleepMe API-tokened már nem érvényes. A kapcsolat helyreállításához adj meg egy új tokent.",
+        "data": {
+          "api_token": "API-token"
+        },
+        "data_description": {
+          "api_token": "Illeszd be a SleepMe Developer API felületén létrehozott új tokent."
+        }
+      }
+    },
+    "error": {
+      "invalid_token": "Érvénytelen API-token. Próbáld újra.",
+      "cannot_connect": "Nem sikerült kapcsolódni a SleepMe API-hoz.",
+      "no_devices_found": "Ehhez az API-tokenhez nem található eszköz.",
+      "cannot_fetch_device_info": "Nem sikerült lekérni az eszköz adatait.",
+      "device_not_found_for_token": "Ez a token nem biztosít hozzáférést az eredetileg beállított eszközhöz."
+    },
+    "abort": {
+      "already_configured": "Ez az eszköz már be van állítva.",
+      "reauth_successful": "Az újbóli hitelesítés sikerült."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "date": { "name": "Legutóbbi alvásjelentés" },
+      "sleep_score_percent": { "name": "Alváspontszám" },
+      "session_count": { "name": "Alvási időszakok száma" },
+      "enter_bed_time": { "name": "Ágyba fekvés" },
+      "exit_bed_time": { "name": "Felkelés az ágyból" },
+      "total_session_duration": { "name": "Alvási időszak teljes hossza" },
+      "in_bed_duration": { "name": "Ágyban töltött idő" },
+      "total_sleep_duration": { "name": "Teljes alvásidő" },
+      "awake_duration": { "name": "Ébren töltött idő" },
+      "light_sleep_duration": { "name": "Könnyű alvás időtartama" },
+      "rem_sleep_duration": { "name": "REM-alvás időtartama" },
+      "deep_sleep_duration": { "name": "Mélyalvás időtartama" },
+      "sleep_latency": { "name": "Elalvási idő" },
+      "hypnogram_segment_count": { "name": "Hipnogramszakaszok száma" },
+      "sleep_efficiency_percent": { "name": "Alváshatékonyság" },
+      "wake_after_sleep_onset": { "name": "Elalvás utáni ébrenlét" },
+      "restorative_sleep_duration": { "name": "Regeneráló alvás időtartama" },
+      "sleep_debt": { "name": "Alvásadósság" },
+      "sleep_goal_percent": { "name": "Alváscél teljesülése" },
+      "awakening_count": { "name": "Ébredések száma" },
+      "longest_uninterrupted_sleep_duration": { "name": "Leghosszabb megszakítás nélküli alvás" },
+      "main_enter_bed_time": { "name": "Fő alvás: ágyba fekvés" },
+      "main_exit_bed_time": { "name": "Fő alvás: felkelés az ágyból" },
+      "sleep_midpoint": { "name": "Alvás közepe" },
+      "nap_count": { "name": "További alvási időszakok száma" },
+      "nap_sleep_duration": { "name": "További alvások időtartama" },
+      "awake_percent": { "name": "Ébrenlét aránya" },
+      "light_sleep_percent": { "name": "Könnyű alvás aránya" },
+      "rem_sleep_percent": { "name": "REM-alvás aránya" },
+      "deep_sleep_percent": { "name": "Mélyalvás aránya" },
+      "restorative_sleep_percent": { "name": "Regeneráló alvás aránya" },
+      "tracked_nights_7d": { "name": "Követett éjszakák száma (7 nap)" },
+      "average_sleep_score_percent_7d": { "name": "Átlagos alváspontszám (7 nap)" },
+      "average_total_sleep_duration_7d": { "name": "Átlagos alvásidő (7 nap)" },
+      "average_sleep_efficiency_percent_7d": { "name": "Átlagos alváshatékonyság (7 nap)" },
+      "average_sleep_latency_7d": { "name": "Átlagos elalvási idő (7 nap)" },
+      "average_deep_sleep_percent_7d": { "name": "Mélyalvás átlagos aránya (7 nap)" },
+      "average_rem_sleep_percent_7d": { "name": "REM-alvás átlagos aránya (7 nap)" },
+      "average_awakening_count_7d": { "name": "Ébredések átlagos száma (7 nap)" },
+      "cumulative_sleep_debt_7d": { "name": "Összesített alvásadósság (7 nap)" },
+      "bedtime_consistency_7d": { "name": "Lefekvési idő ingadozása (7 nap)" },
+      "wake_time_consistency_7d": { "name": "Felkelési idő ingadozása (7 nap)" },
+      "tracked_nights_30d": { "name": "Követett éjszakák száma (30 nap)" },
+      "average_sleep_score_percent_30d": { "name": "Átlagos alváspontszám (30 nap)" },
+      "average_total_sleep_duration_30d": { "name": "Átlagos alvásidő (30 nap)" },
+      "average_sleep_efficiency_percent_30d": { "name": "Átlagos alváshatékonyság (30 nap)" },
+      "average_sleep_latency_30d": { "name": "Átlagos elalvási idő (30 nap)" },
+      "average_deep_sleep_percent_30d": { "name": "Mélyalvás átlagos aránya (30 nap)" },
+      "average_rem_sleep_percent_30d": { "name": "REM-alvás átlagos aránya (30 nap)" },
+      "average_awakening_count_30d": { "name": "Ébredések átlagos száma (30 nap)" },
+      "cumulative_sleep_debt_30d": { "name": "Összesített alvásadósság (30 nap)" },
+      "bedtime_consistency_30d": { "name": "Lefekvési idő ingadozása (30 nap)" },
+      "wake_time_consistency_30d": { "name": "Felkelési idő ingadozása (30 nap)" }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "SleepMe-eszköz beállításai",
+        "description": "Állítsd be, milyen gyakran kérdezze le a Home Assistant a SleepMe API-t. Sleep Tracker használatakor azt az egyéni éjszakai alváscélt is megadhatod, amelyből a Home Assistant kiszámítja az alváscél és az alvásadósság érzékelőinek értékét.",
+        "data": {
+          "scan_interval": "Lekérdezési időköz (másodperc)",
+          "sleep_target_hours": "Éjszakai alváscél (óra)"
+        }
+      }
+    },
+    "error": {
+      "invalid_scan_interval": "A lekérdezési időköznek 10 és 300 másodperc között kell lennie.",
+      "invalid_sleep_target": "Az éjszakai alváscélnak 4 és 12 óra között kell lennie."
+    }
+  },
+  "services": {
+    "get_sleep_reports": {
+      "name": "Alvásjelentések lekérése",
+      "description": "Lekéri a fiókhoz tartozó SleepMe-alvásjelentések teljes, nyers adatkészletét. A válasz tartalmazza az alvási időszakokat és az egyes hipnogramok szakaszait; a Home Assistant nem menti az előzményekbe.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Konfigurációs bejegyzés",
+          "description": "A betöltött SleepMe konfigurációs bejegyzés, amelyhez tartozó API-tokent a művelet használja."
+        },
+        "start_date": {
+          "name": "Záró dátum",
+          "description": "A lekérendő utolsó jelentés dátuma. Alapértelmezés szerint a kiválasztott időzóna szerinti mai nap."
+        },
+        "days_back": {
+          "name": "Korábbi napok száma",
+          "description": "A záró dátum előtti napok száma nullától hatig."
+        },
+        "time_zone": {
+          "name": "Időzóna",
+          "description": "IANA-időzónanév. Alapértelmezés szerint a Home Assistant beállított időzónája."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/sleepme_thermostat/update_manager.py
+++ b/custom_components/sleepme_thermostat/update_manager.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -22,6 +22,7 @@ from homeassistant.config_entries import ConfigEntryAuthFailed
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from .const import MAX_SLEEP_REPORT_DAYS_BACK
 from .sleepme import SleepMeClient
 from .sleepme_api import (
     SleepMeAuthError,
@@ -82,7 +83,7 @@ class SleepMeUpdateManager(DataUpdateCoordinator):
 
 
 class SleepReportUpdateManager(DataUpdateCoordinator[list[dict[str, Any]]]):
-    """Fetch the account's seven-day sleep-report window at a gentle cadence."""
+    """Fetch account sleep-report history in API-sized date windows."""
 
     def __init__(
         self,
@@ -91,12 +92,12 @@ class SleepReportUpdateManager(DataUpdateCoordinator[list[dict[str, Any]]]):
         token: str,
         *,
         time_zone: str,
-        days_back: int,
+        history_days: int,
         scan_interval: int,
     ) -> None:
         self.client = SleepMeClient(hass, api_url, token)
         self.time_zone = time_zone
-        self.days_back = days_back
+        self.history_days = history_days
         super().__init__(
             hass,
             _LOGGER,
@@ -105,11 +106,43 @@ class SleepReportUpdateManager(DataUpdateCoordinator[list[dict[str, Any]]]):
         )
 
     async def _async_update_data(self) -> list[dict[str, Any]]:
-        """Fetch reports through today in Home Assistant's configured zone."""
-        return await _async_fetch(
-            self.client.get_sleep_reports(
-                start_date=datetime.now(ZoneInfo(self.time_zone)).date(),
-                days_back=self.days_back,
-                time_zone=self.time_zone,
+        """Fetch and merge non-overlapping report windows through today."""
+        end_date = datetime.now(ZoneInfo(self.time_zone)).date()
+        reports_by_date: dict[str, dict[str, Any]] = {}
+        undated_reports: list[dict[str, Any]] = []
+
+        for window_end, days_back in _report_windows(end_date, self.history_days):
+            reports = await _async_fetch(
+                self.client.get_sleep_reports(
+                    start_date=window_end,
+                    days_back=days_back,
+                    time_zone=self.time_zone,
+                )
             )
-        )
+            for report in reports:
+                report_date = report.get("date")
+                if isinstance(report_date, str):
+                    reports_by_date[report_date] = report
+                else:
+                    undated_reports.append(report)
+
+        return [
+            *(reports_by_date[key] for key in sorted(reports_by_date)),
+            *undated_reports,
+        ]
+
+
+def _report_windows(end_date: date, history_days: int) -> list[tuple[date, int]]:
+    """Split a history range into the endpoint's inclusive seven-day windows."""
+    windows: list[tuple[date, int]] = []
+    remaining = max(history_days, 1)
+    window_end = end_date
+    max_window_days = MAX_SLEEP_REPORT_DAYS_BACK + 1
+
+    while remaining:
+        window_days = min(remaining, max_window_days)
+        windows.append((window_end, window_days - 1))
+        remaining -= window_days
+        window_end -= timedelta(days=window_days)
+
+    return windows

--- a/custom_components/sleepme_thermostat/update_manager.py
+++ b/custom_components/sleepme_thermostat/update_manager.py
@@ -12,7 +12,10 @@ successful update).
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
+from collections.abc import Awaitable
+from datetime import datetime, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
 
 import httpx
 from homeassistant.config_entries import ConfigEntryAuthFailed
@@ -27,6 +30,24 @@ from .sleepme_api import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def _async_fetch[T](coro: Awaitable[T]) -> T:
+    """Run a client request and translate transport failures for coordinators."""
+    try:
+        return await coro
+    except SleepMeAuthError as err:
+        raise ConfigEntryAuthFailed("Invalid or revoked SleepMe API token") from err
+    except SleepMeRateLimited as err:
+        raise UpdateFailed(
+            "SleepMe API rate-limited; will retry next interval"
+        ) from err
+    except SleepMeConnectionError as err:
+        raise UpdateFailed(f"Cannot reach SleepMe API: {err}") from err
+    except httpx.HTTPStatusError as err:
+        raise UpdateFailed(f"HTTP {err.response.status_code} from SleepMe API") from err
+    except ValueError as err:
+        raise UpdateFailed(str(err)) from err
 
 
 class SleepMeUpdateManager(DataUpdateCoordinator):
@@ -51,26 +72,44 @@ class SleepMeUpdateManager(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict:
         """Fetch the latest device status. Raise typed framework exceptions on failure."""
-        try:
-            device_status = await self.client.get_device_status()
-        except SleepMeAuthError as err:
-            raise ConfigEntryAuthFailed("Invalid or revoked SleepMe API token") from err
-        except SleepMeRateLimited as err:
-            raise UpdateFailed(
-                "SleepMe API rate-limited; will retry next interval"
-            ) from err
-        except SleepMeConnectionError as err:
-            raise UpdateFailed(f"Cannot reach SleepMe API: {err}") from err
-        except httpx.HTTPStatusError as err:
-            # Non-401/403/429/5xx HTTP errors that transport let through.
-            raise UpdateFailed(
-                f"HTTP {err.response.status_code} from SleepMe API"
-            ) from err
-        except ValueError as err:
-            raise UpdateFailed(str(err)) from err
+        device_status = await _async_fetch(self.client.get_device_status())
 
         return {
             "status": device_status.get("status", {}),
             "control": device_status.get("control", {}),
             "about": device_status.get("about", {}),
         }
+
+
+class SleepReportUpdateManager(DataUpdateCoordinator[list[dict[str, Any]]]):
+    """Fetch the account's seven-day sleep-report window at a gentle cadence."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        api_url: str,
+        token: str,
+        *,
+        time_zone: str,
+        days_back: int,
+        scan_interval: int,
+    ) -> None:
+        self.client = SleepMeClient(hass, api_url, token)
+        self.time_zone = time_zone
+        self.days_back = days_back
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="SleepMe Sleep Reports",
+            update_interval=timedelta(seconds=scan_interval),
+        )
+
+    async def _async_update_data(self) -> list[dict[str, Any]]:
+        """Fetch reports through today in Home Assistant's configured zone."""
+        return await _async_fetch(
+            self.client.get_sleep_reports(
+                start_date=datetime.now(ZoneInfo(self.time_zone)).date(),
+                days_back=self.days_back,
+                time_zone=self.time_zone,
+            )
+        )

--- a/docs/examples/sleep_tracker_dashboard.yaml
+++ b/docs/examples/sleep_tracker_dashboard.yaml
@@ -1,0 +1,70 @@
+# Stock Home Assistant dashboard cards for SleepMe Tracker data.
+# Replace every example entity_id with the IDs created in your installation.
+type: vertical-stack
+cards:
+  - type: entities
+    title: Last sleep
+    show_header_toggle: false
+    entities:
+      - entity: sensor.sleep_tracker_last_sleep_report
+      - entity: sensor.sleep_tracker_sleep_score
+      - entity: sensor.sleep_tracker_total_sleep_duration
+      - entity: sensor.sleep_tracker_sleep_efficiency
+      - entity: sensor.sleep_tracker_sleep_goal
+      - entity: sensor.sleep_tracker_sleep_debt
+      - entity: sensor.sleep_tracker_awakenings
+      - entity: sensor.sleep_tracker_longest_uninterrupted_sleep
+      - entity: sensor.sleep_tracker_sleep_midpoint
+
+  - type: horizontal-stack
+    cards:
+      - type: gauge
+        name: Efficiency
+        entity: sensor.sleep_tracker_sleep_efficiency
+        min: 0
+        max: 100
+        severity:
+          red: 0
+          yellow: 75
+          green: 85
+      - type: gauge
+        name: Sleep goal
+        entity: sensor.sleep_tracker_sleep_goal
+        min: 0
+        max: 120
+        severity:
+          red: 0
+          yellow: 75
+          green: 95
+
+  - type: entities
+    title: Sleep composition
+    show_header_toggle: false
+    entities:
+      - entity: sensor.sleep_tracker_awake_percentage
+      - entity: sensor.sleep_tracker_light_sleep_percentage
+      - entity: sensor.sleep_tracker_rem_sleep_percentage
+      - entity: sensor.sleep_tracker_deep_sleep_percentage
+      - entity: sensor.sleep_tracker_restorative_sleep_percentage
+
+  - type: entities
+    title: Trends
+    show_header_toggle: false
+    entities:
+      - entity: sensor.sleep_tracker_average_sleep_score_7_day
+      - entity: sensor.sleep_tracker_average_sleep_duration_7_day
+      - entity: sensor.sleep_tracker_average_sleep_efficiency_7_day
+      - entity: sensor.sleep_tracker_bedtime_consistency_7_day
+      - entity: sensor.sleep_tracker_wake_time_consistency_7_day
+      - entity: sensor.sleep_tracker_cumulative_sleep_debt_7_day
+      - entity: sensor.sleep_tracker_average_sleep_score_30_day
+      - entity: sensor.sleep_tracker_average_sleep_duration_30_day
+
+  - type: history-graph
+    title: Bed presence and environment
+    hours_to_show: 24
+    entities:
+      - entity: binary_sensor.sleep_tracker_user_detected
+      - entity: sensor.sleep_tracker_bed_temperature
+      - entity: sensor.sleep_tracker_environment_temperature
+      - entity: sensor.sleep_tracker_environment_humidity

--- a/docs/phase-6-followup.md
+++ b/docs/phase-6-followup.md
@@ -560,7 +560,7 @@ ssh hassio@100.88.154.98 'jq ".data.entities[] | select(.platform == \"sleepme_t
 | Writable `number.brightness_level` | Phase 7+ |
 | Writable `select.display_temperature_unit` | Phase 7+ |
 | `set_temperature_f` when HA is in Fahrenheit | Phase 7+ (small but needs design — does HA's climate platform pass C or F to us?) |
-| Sleep Tracker (ST501NA) platform | Phase 7+ (whole new device class) |
+| Sleep Tracker (ST501NA) platform | Implemented for v4.3.0 after Phase 6 |
 | Split-bed (WE) pairing UX | Phase 7+ |
 | HA-side Sleep Programs blueprint | Phase 7+ |
 | `EntityDescription` refactor + entity/icon translations | Phase 7+ (unblocks HA Gold rules for translation) |

--- a/docs/sleep-tracker.md
+++ b/docs/sleep-tracker.md
@@ -1,0 +1,65 @@
+# Sleep Tracker data and Home Assistant features
+
+The ST501NA exposes two useful data paths through Sleepme's public API:
+
+1. Live device status: occupancy, connectivity, bed temperature, room temperature, and room humidity.
+2. Finalized daily reports: score, sessions, timestamps, duration totals, stage totals, and hypnogram segments.
+
+Home Assistant polls live status at the configured device interval. It fetches reports every 30 minutes in five non-overlapping API-sized windows, yielding 30 calendar days of history. Reports generally appear only after Sleepme finalizes a session, so report sensors are not real-time sleep-stage sensors.
+
+## Direct and derived sensors
+
+| Feature | Source or formula | Classification |
+|---|---|---|
+| Bed occupied, environment/bed temperature, humidity, connectivity | Live device status | Direct |
+| Sleep score, session count, duration/stage totals, latency, entry/exit | Daily report fields, summed across sessions | Direct aggregation |
+| Sleep efficiency | `total sleep / in-bed duration × 100` | HA-derived |
+| Wake after sleep onset (WASO) | `max(awake duration - sleep latency, 0)` | HA-derived approximation |
+| Awake percentage | `awake duration / in-bed duration × 100` | HA-derived |
+| Light, REM, deep percentage | Stage duration / total sleep × 100 | HA-derived |
+| Restorative sleep | REM + deep duration and percentage | HA-derived convention |
+| Sleep goal percentage | Total sleep / configured HA target × 100 | HA-derived |
+| Nightly sleep debt | `max(configured target - total sleep, 0)` | HA-derived |
+| Awakenings | Number of hypnogram transitions from a sleep stage to awake | HA-derived; not a movement count |
+| Longest uninterrupted sleep | Longest contiguous run of light/REM/deep hypnogram segments | HA-derived |
+| Main sleep and midpoint | Longest session; midpoint between its entry and exit | HA-derived heuristic |
+| Additional sessions | Every session other than the longest, with total sleep summed | HA-derived heuristic; the API does not label naps |
+| 7/30-day averages | Mean across completed reports in each calendar window | HA-derived |
+| Bed/wake consistency | Mean circular clock-time deviation, in minutes | HA-derived; lower is more consistent |
+| 7/30-day cumulative debt | Sum of nightly debt across tracked nights | HA-derived |
+
+The personal sleep target is configured under *Settings → Devices & Services → SleepMe → Configure*. It defaults to eight hours and affects only HA-derived goal/debt sensors; it is not presented as medical guidance or a Sleepme recommendation.
+
+## What pure Home Assistant can reproduce
+
+| Sleepme-style capability | Pure HA result |
+|---|---|
+| Bed presence routines | Fully reproducible from live occupancy using the included occupancy blueprint |
+| Schedule plus early/late bedtime Dock response | Reproducible with occupancy, time triggers, and the presence-aware Dock blueprint |
+| Wake-early and snooze behavior | Reproducible: delayed empty triggers cancel on a quick return; scheduled end remains deterministic |
+| Return-to-bed temperature assistance | Approximate, user-controlled rule via the included temporary-adjustment blueprint |
+| Sleep-quality summaries and threshold alerts | Reproducible from finalized report sensors |
+| Trend dashboards and correlations with room climate | Reproducible using Recorder/history/statistics and HA dashboards |
+| Hiber-AI automatic temperature optimization | Not reproducible exactly; its model/inputs are proprietary and the public API exposes no equivalent control signal |
+| Smart alarm based on current sleep stage | Not reproducible because reports and stages are finalized, not live |
+| Heart rate, HRV, respiration | Not available in the current public response |
+| True movement/disturbance events | Not available as labeled public fields; awakenings are only stage transitions |
+
+## Included blueprints
+
+The repository ships four automation blueprints under `blueprints/automation/sleepme_thermostat/`. Import the desired raw GitHub URL in HA's Blueprint UI after this branch is merged.
+
+- `tracker_occupancy_actions.yaml`: independent occupied/empty delays and arbitrary action selectors.
+- `dock_presence_control.yaml`: an overnight window, early-start allowance, scheduled start/end, occupancy gating, and delayed shutdown.
+- `dock_back_to_sleep.yaml`: waits for a return after an overnight absence, applies a signed target-temperature adjustment, and restores the original setpoint.
+- `sleep_report_alert.yaml`: evaluates a finalized report against visible thresholds and exposes `sleepme_alert_message` to notification actions.
+
+The return-to-bed automation is intentionally described as a heuristic rather than Hiber-AI. Start with a small signed adjustment appropriate for your HA temperature unit, observe comfort, and disable it if it conflicts with another Dock schedule.
+
+## Privacy and Recorder behavior
+
+Normal entities expose only scalar values. Raw hypnogram arrays and session IDs are never added as state attributes or diagnostics, preventing Recorder from copying the full health payload every refresh. Use the response-only `sleepme_thermostat.get_sleep_reports` action for an explicit lossless fetch when needed.
+
+## Language behavior
+
+HA currently advertises 65 frontend locales. Entity and options strings use HA translation keys. The project includes English source strings and Spanish translations; every remaining HA locale is tested to resolve the English fallback, so controls and names remain usable without pretending that unreviewed machine translations are native-quality localization.

--- a/docs/sleep-tracker.md
+++ b/docs/sleep-tracker.md
@@ -68,4 +68,4 @@ Normal entities expose only scalar values. Raw hypnogram arrays and session IDs 
 
 ## Language behavior
 
-HA currently advertises 65 frontend locales. Entity and options strings use HA translation keys. The project includes English source strings and Spanish translations; every remaining HA locale is tested to resolve the English fallback, so controls and names remain usable without pretending that unreviewed machine translations are native-quality localization.
+HA currently advertises 65 frontend locales. Entity and options strings use HA translation keys. The project includes English source strings, Spanish translations, and complete native Hungarian translations; every remaining HA locale is tested to resolve the English fallback, so controls and names remain usable without pretending that unreviewed machine translations are native-quality localization.

--- a/docs/sleep-tracker.md
+++ b/docs/sleep-tracker.md
@@ -7,6 +7,8 @@ The ST501NA exposes two useful data paths through Sleepme's public API:
 
 Home Assistant polls live status at the configured device interval. It fetches reports every 30 minutes in five non-overlapping API-sized windows, yielding 30 calendar days of history. Reports generally appear only after Sleepme finalizes a session, so report sensors are not real-time sleep-stage sensors.
 
+The public report payload uses minutes for durations and hypnogram offsets. The integration converts these values to seconds at the aggregation boundary, matching Home Assistant's duration entity convention. The lossless response action returns the raw API values unchanged.
+
 ## Direct and derived sensors
 
 | Feature | Source or formula | Classification |
@@ -35,8 +37,11 @@ The personal sleep target is configured under *Settings â†’ Devices & Services â
 | Sleepme-style capability | Pure HA result |
 |---|---|
 | Bed presence routines | Fully reproducible from live occupancy using the included occupancy blueprint |
-| Schedule plus early/late bedtime Dock response | Reproducible with occupancy, time triggers, and the presence-aware Dock blueprint |
-| Wake-early and snooze behavior | Reproducible: delayed empty triggers cancel on a quick return; scheduled end remains deterministic |
+| Early to bed | Reproducible: occupancy within a configurable pre-bedtime window starts the Dock |
+| Late to bed | Reproducible: an empty bed stays off at bedtime and later occupancy starts the Dock inside the overnight window |
+| Wake up early | Reproducible: confirmed empty-bed state stops the Dock before the scheduled end |
+| Snooze | Reproducible: occupancy at wake time uses a configurable extension; a later empty event can stop it sooner |
+| Warm Awake | Reproducible with the included occupied-bed warm-awake blueprint; lead time, temperature, and duration remain explicit HA inputs |
 | Return-to-bed temperature assistance | Approximate, user-controlled rule via the included temporary-adjustment blueprint |
 | Sleep-quality summaries and threshold alerts | Reproducible from finalized report sensors |
 | Trend dashboards and correlations with room climate | Reproducible using Recorder/history/statistics and HA dashboards |
@@ -47,11 +52,12 @@ The personal sleep target is configured under *Settings â†’ Devices & Services â
 
 ## Included blueprints
 
-The repository ships four automation blueprints under `blueprints/automation/sleepme_thermostat/`. Import the desired raw GitHub URL in HA's Blueprint UI after this branch is merged.
+The repository ships five automation blueprints under `blueprints/automation/sleepme_thermostat/`. Import the desired raw GitHub URL in HA's Blueprint UI after this branch is merged.
 
 - `tracker_occupancy_actions.yaml`: independent occupied/empty delays and arbitrary action selectors.
-- `dock_presence_control.yaml`: an overnight window, early-start allowance, scheduled start/end, occupancy gating, and delayed shutdown.
-- `dock_back_to_sleep.yaml`: waits for a return after an overnight absence, applies a signed target-temperature adjustment, and restores the original setpoint.
+- `dock_presence_control.yaml`: an overnight window, early-start allowance, scheduled start/end, occupancy gating, delayed empty shutdown, and configurable extension while still occupied at wake time.
+- `dock_back_to_sleep.yaml`: waits for a return after an overnight absence, applies a signed target-temperature adjustment, and restores the original setpoint. Its default warming step approximates Sleepme's documented +5 Â°F behavior in Celsius-oriented installations and remains user-configurable.
+- `tracker_warm_awake.yaml`: starts before wake time only when the bed is occupied, warms for the chosen duration, then stops the Dock.
 - `sleep_report_alert.yaml`: evaluates a finalized report against visible thresholds and exposes `sleepme_alert_message` to notification actions.
 
 The return-to-bed automation is intentionally described as a heuristic rather than Hiber-AI. Start with a small signed adjustment appropriate for your HA temperature unit, observe comfort, and disable it if it conflicts with another Dock schedule.

--- a/hacs.json
+++ b/hacs.json
@@ -1,3 +1,3 @@
 {
-    "name": "SleepMe (Chilipad Dock Pro)"
+    "name": "SleepMe"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "sleepme_thermostat"
 version = "0.0.0"
-description = "Home Assistant custom integration for SleepMe Dock Pro"
+description = "Home Assistant integration for SleepMe Chilipad and Sleep Tracker devices"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.14"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Generator
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 pytest_plugins = ["pytest_homeassistant_custom_component"]
+
+FIXTURES = Path(__file__).parent / "fixtures"
 
 
 @pytest.fixture(autouse=True)
@@ -17,7 +21,20 @@ def auto_enable_custom_integrations(enable_custom_integrations):
 
 
 @pytest.fixture
-def mock_sleepme_client() -> Generator[AsyncMock]:
+def tracker_status() -> dict:
+    """Return the fabricated ST501NA device-status fixture."""
+    return json.loads((FIXTURES / "tracker_status.json").read_text())
+
+
+@pytest.fixture
+def sleep_reports() -> list[dict]:
+    """Return fabricated sleep reports matching the live public API schema."""
+    payload = json.loads((FIXTURES / "sleep_reports.json").read_text())
+    return payload["reports"]
+
+
+@pytest.fixture
+def mock_sleepme_client(sleep_reports: list[dict]) -> Generator[AsyncMock]:
     """Mock SleepMeClient so no real network calls happen.
 
     Patches both import sites:
@@ -58,10 +75,12 @@ def mock_sleepme_client() -> Generator[AsyncMock]:
             autospec=True,
         ) as mock_um,
     ):
-        for mock_cls in (mock_init, mock_um):
-            instance = mock_cls.return_value
-            instance.get_device_status = AsyncMock(return_value=healthy_status)
-            instance.get_claimed_devices = AsyncMock(return_value=[])
-            instance.set_temp_level = AsyncMock(return_value={})
-            instance.set_device_status = AsyncMock(return_value={})
-        yield mock_init.return_value
+        instance = AsyncMock()
+        instance.get_device_status = AsyncMock(return_value=healthy_status)
+        instance.get_claimed_devices = AsyncMock(return_value=[])
+        instance.get_sleep_reports = AsyncMock(return_value=sleep_reports)
+        instance.set_temp_level = AsyncMock(return_value={})
+        instance.set_device_status = AsyncMock(return_value={})
+        mock_init.return_value = instance
+        mock_um.return_value = instance
+        yield instance

--- a/tests/fixtures/sleep_reports.json
+++ b/tests/fixtures/sleep_reports.json
@@ -12,19 +12,19 @@
           "id": "session-older",
           "enter_bed_time": "2026-07-10T22:30:00+02:00",
           "exit_bed_time": "2026-07-11T06:30:00+02:00",
-          "total_session_duration": 28800,
-          "in_bed_duration": 28200,
-          "total_sleep_duration": 25200,
-          "awake_duration": 3000,
-          "light_sleep_duration": 12600,
-          "rem_sleep_duration": 6300,
-          "deep_sleep_duration": 6300,
-          "sleep_latency": 900,
+          "total_session_duration": 480,
+          "in_bed_duration": 470,
+          "total_sleep_duration": 420,
+          "awake_duration": 50,
+          "light_sleep_duration": 210,
+          "rem_sleep_duration": 105,
+          "deep_sleep_duration": 105,
+          "sleep_latency": 15,
           "hypnogram": {
             "raw_hypnogram_segment_count": 2,
             "segments": [
-              {"start": 0, "end": 900, "stage": "AWAKE"},
-              {"start": 900, "end": 28800, "stage": "LIGHT_SLEEP"}
+              {"start": 0, "end": 15, "stage": "AWAKE"},
+              {"start": 15, "end": 480, "stage": "LIGHT_SLEEP"}
             ]
           }
         }
@@ -38,20 +38,20 @@
           "id": "session-nap",
           "enter_bed_time": "2026-07-12T14:00:00+02:00",
           "exit_bed_time": "2026-07-12T16:00:00+02:00",
-          "total_session_duration": 7200,
-          "in_bed_duration": 7000,
-          "total_sleep_duration": 6000,
-          "awake_duration": 1000,
-          "light_sleep_duration": 3000,
-          "rem_sleep_duration": 1500,
-          "deep_sleep_duration": 1500,
-          "sleep_latency": 500,
+          "total_session_duration": 120,
+          "in_bed_duration": 117,
+          "total_sleep_duration": 100,
+          "awake_duration": 17,
+          "light_sleep_duration": 50,
+          "rem_sleep_duration": 25,
+          "deep_sleep_duration": 25,
+          "sleep_latency": 8,
           "hypnogram": {
             "raw_hypnogram_segment_count": 3,
             "segments": [
-              {"start": 0, "end": 500, "stage": "AWAKE"},
-              {"start": 500, "end": 3600, "stage": "LIGHT_SLEEP"},
-              {"start": 3600, "end": 7200, "stage": "DEEP_SLEEP"}
+              {"start": 0, "end": 8, "stage": "AWAKE"},
+              {"start": 8, "end": 60, "stage": "LIGHT_SLEEP"},
+              {"start": 60, "end": 120, "stage": "DEEP_SLEEP"}
             ]
           }
         },
@@ -59,21 +59,21 @@
           "id": "session-main",
           "enter_bed_time": "2026-07-12T23:00:00+02:00",
           "exit_bed_time": "2026-07-13T07:00:00+02:00",
-          "total_session_duration": 28800,
-          "in_bed_duration": 28000,
-          "total_sleep_duration": 25200,
-          "awake_duration": 2800,
-          "light_sleep_duration": 12600,
-          "rem_sleep_duration": 6300,
-          "deep_sleep_duration": 6300,
-          "sleep_latency": 900,
+          "total_session_duration": 480,
+          "in_bed_duration": 467,
+          "total_sleep_duration": 420,
+          "awake_duration": 47,
+          "light_sleep_duration": 210,
+          "rem_sleep_duration": 105,
+          "deep_sleep_duration": 105,
+          "sleep_latency": 15,
           "hypnogram": {
             "raw_hypnogram_segment_count": 4,
             "segments": [
-              {"start": 0, "end": 900, "stage": "AWAKE"},
-              {"start": 900, "end": 10800, "stage": "LIGHT_SLEEP"},
-              {"start": 10800, "end": 18000, "stage": "REM_SLEEP"},
-              {"start": 18000, "end": 28800, "stage": "DEEP_SLEEP"}
+              {"start": 0, "end": 15, "stage": "AWAKE"},
+              {"start": 15, "end": 180, "stage": "LIGHT_SLEEP"},
+              {"start": 180, "end": 300, "stage": "REM_SLEEP"},
+              {"start": 300, "end": 480, "stage": "DEEP_SLEEP"}
             ]
           }
         }

--- a/tests/fixtures/sleep_reports.json
+++ b/tests/fixtures/sleep_reports.json
@@ -1,0 +1,84 @@
+{
+  "reports": [
+    {
+      "date": "2026-07-13",
+      "sessions": [],
+      "sleep_score_percent": 0
+    },
+    {
+      "date": "2026-07-11",
+      "sessions": [
+        {
+          "id": "session-older",
+          "enter_bed_time": "2026-07-10T22:30:00+02:00",
+          "exit_bed_time": "2026-07-11T06:30:00+02:00",
+          "total_session_duration": 28800,
+          "in_bed_duration": 28200,
+          "total_sleep_duration": 25200,
+          "awake_duration": 3000,
+          "light_sleep_duration": 12600,
+          "rem_sleep_duration": 6300,
+          "deep_sleep_duration": 6300,
+          "sleep_latency": 900,
+          "hypnogram": {
+            "raw_hypnogram_segment_count": 2,
+            "segments": [
+              {"start": 0, "end": 900, "stage": "AWAKE"},
+              {"start": 900, "end": 28800, "stage": "LIGHT_SLEEP"}
+            ]
+          }
+        }
+      ],
+      "sleep_score_percent": 80
+    },
+    {
+      "date": "2026-07-12",
+      "sessions": [
+        {
+          "id": "session-nap",
+          "enter_bed_time": "2026-07-12T14:00:00+02:00",
+          "exit_bed_time": "2026-07-12T16:00:00+02:00",
+          "total_session_duration": 7200,
+          "in_bed_duration": 7000,
+          "total_sleep_duration": 6000,
+          "awake_duration": 1000,
+          "light_sleep_duration": 3000,
+          "rem_sleep_duration": 1500,
+          "deep_sleep_duration": 1500,
+          "sleep_latency": 500,
+          "hypnogram": {
+            "raw_hypnogram_segment_count": 3,
+            "segments": [
+              {"start": 0, "end": 500, "stage": "AWAKE"},
+              {"start": 500, "end": 3600, "stage": "LIGHT_SLEEP"},
+              {"start": 3600, "end": 7200, "stage": "DEEP_SLEEP"}
+            ]
+          }
+        },
+        {
+          "id": "session-main",
+          "enter_bed_time": "2026-07-12T23:00:00+02:00",
+          "exit_bed_time": "2026-07-13T07:00:00+02:00",
+          "total_session_duration": 28800,
+          "in_bed_duration": 28000,
+          "total_sleep_duration": 25200,
+          "awake_duration": 2800,
+          "light_sleep_duration": 12600,
+          "rem_sleep_duration": 6300,
+          "deep_sleep_duration": 6300,
+          "sleep_latency": 900,
+          "hypnogram": {
+            "raw_hypnogram_segment_count": 4,
+            "segments": [
+              {"start": 0, "end": 900, "stage": "AWAKE"},
+              {"start": 900, "end": 10800, "stage": "LIGHT_SLEEP"},
+              {"start": 10800, "end": 18000, "stage": "REM_SLEEP"},
+              {"start": 18000, "end": 28800, "stage": "DEEP_SLEEP"}
+            ]
+          }
+        }
+      ],
+      "sleep_score_percent": 88
+    }
+  ]
+}

--- a/tests/fixtures/tracker_status.json
+++ b/tests/fixtures/tracker_status.json
@@ -1,0 +1,20 @@
+{
+  "status": {
+    "is_connected": true,
+    "user_detected": true,
+    "environment_humidity": 47.5,
+    "environment_temperature_f": 70.7,
+    "environment_temperature_c": 21.5,
+    "bed_temperature_f": 82.4,
+    "bed_temperature_c": 28.0
+  },
+  "control": {},
+  "about": {
+    "firmware_version": "2.3.4-test",
+    "mac_address": "11:22:33:44:55:66",
+    "model": "ST501NA",
+    "serial_number": "TRACKER-TEST-SERIAL",
+    "ip_address": "203.0.113.10",
+    "lan_address": "192.0.2.10"
+  }
+}

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -1,0 +1,256 @@
+"""Validate shipped automation blueprints after input substitution."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from custom_components.sleepme_thermostat.const import DOMAIN
+from homeassistant.components.automation.config import (
+    AUTOMATION_BLUEPRINT_SCHEMA,
+    ValidationStatus,
+    async_validate_config_item,
+)
+from homeassistant.components.blueprint.models import Blueprint, BlueprintInputs
+from homeassistant.core import HomeAssistant
+from homeassistant.generated.languages import LANGUAGES
+from homeassistant.helpers import translation
+from homeassistant.setup import async_setup_component
+from homeassistant.util import yaml as yaml_util
+from pytest_homeassistant_custom_component.common import async_mock_service
+
+BLUEPRINTS = (
+    Path(__file__).parents[1] / "blueprints" / "automation" / "sleepme_thermostat"
+)
+
+BLUEPRINT_INPUTS = {
+    "tracker_occupancy_actions.yaml": {
+        "occupancy_sensor": "binary_sensor.sleepme_user_detected",
+    },
+    "dock_presence_control.yaml": {
+        "occupancy_sensor": "binary_sensor.sleepme_user_detected",
+        "dock_climate": "climate.sleepme_dock",
+    },
+    "dock_back_to_sleep.yaml": {
+        "occupancy_sensor": "binary_sensor.sleepme_user_detected",
+        "dock_climate": "climate.sleepme_dock",
+    },
+    "sleep_report_alert.yaml": {
+        "report_date_sensor": "sensor.sleepme_last_report",
+        "score_sensor": "sensor.sleepme_score",
+        "duration_sensor": "sensor.sleepme_duration",
+        "efficiency_sensor": "sensor.sleepme_efficiency",
+        "latency_sensor": "sensor.sleepme_latency",
+        "deep_sleep_sensor": "sensor.sleepme_deep_sleep",
+        "alert_actions": [
+            {
+                "action": "persistent_notification.create",
+                "data": {"message": "{{ sleepme_alert_message }}"},
+            }
+        ],
+    },
+}
+
+
+def _substituted_config(filename: str, overrides: dict | None = None) -> dict:
+    """Load a blueprint and replace all input tags with test values."""
+    path = BLUEPRINTS / filename
+    blueprint = Blueprint(
+        yaml_util.load_yaml(path),
+        path=str(path),
+        expected_domain="automation",
+        schema=AUTOMATION_BLUEPRINT_SCHEMA,
+    )
+    values = {**BLUEPRINT_INPUTS[filename], **(overrides or {})}
+    inputs = BlueprintInputs(
+        blueprint,
+        {
+            "use_blueprint": {
+                "path": f"sleepme_thermostat/{filename}",
+                "input": values,
+            }
+        },
+    )
+    inputs.validate()
+    return inputs.async_substitute()
+
+
+@pytest.mark.parametrize("filename", sorted(BLUEPRINT_INPUTS))
+async def test_blueprint_is_valid_after_substitution(
+    hass: HomeAssistant, filename: str
+) -> None:
+    """Metadata, selectors, triggers, templates, and actions satisfy HA schemas."""
+    path = BLUEPRINTS / filename
+    blueprint = Blueprint(
+        yaml_util.load_yaml(path),
+        path=str(path),
+        expected_domain="automation",
+        schema=AUTOMATION_BLUEPRINT_SCHEMA,
+    )
+    assert blueprint.validate() is None
+
+    config = _substituted_config(filename)
+    validated = await async_validate_config_item(hass, filename, config)
+
+    assert validated is not None
+    assert validated.validation_status is ValidationStatus.OK
+
+
+async def test_occupancy_blueprint_runs_both_action_branches(
+    hass: HomeAssistant,
+) -> None:
+    """Confirmed bed entry and exit invoke their independent action selectors."""
+    occupied_calls = async_mock_service(hass, "test", "occupied")
+    empty_calls = async_mock_service(hass, "test", "empty")
+    occupancy = "binary_sensor.sleepme_user_detected"
+    hass.states.async_set(occupancy, "off")
+    config = _substituted_config(
+        "tracker_occupancy_actions.yaml",
+        {
+            "occupied_delay": {"seconds": 0},
+            "empty_delay": {"seconds": 0},
+            "occupied_actions": [{"action": "test.occupied"}],
+            "empty_actions": [{"action": "test.empty"}],
+        },
+    )
+    config.update({"id": "test_occupancy", "alias": "Test occupancy"})
+    assert await async_setup_component(hass, "automation", {"automation": [config]})
+
+    hass.states.async_set(occupancy, "on")
+    await hass.async_block_till_done()
+    hass.states.async_set(occupancy, "off")
+    await hass.async_block_till_done()
+
+    assert len(occupied_calls) == 1
+    assert len(empty_calls) == 1
+
+
+async def test_presence_control_blueprint_starts_and_stops_dock(
+    hass: HomeAssistant,
+) -> None:
+    """Occupancy within the active window sets mode/temperature, then stops."""
+    mode_calls = async_mock_service(hass, "climate", "set_hvac_mode")
+    temperature_calls = async_mock_service(hass, "climate", "set_temperature")
+    off_calls = async_mock_service(hass, "climate", "turn_off")
+    occupancy = "binary_sensor.sleepme_user_detected"
+    hass.states.async_set(occupancy, "off")
+    config = _substituted_config(
+        "dock_presence_control.yaml",
+        {
+            "sleep_start_time": "00:00:00",
+            "sleep_end_time": "23:59:59",
+            "early_start_window": 0,
+            "target_temperature": 20.5,
+            "empty_delay": {"seconds": 0},
+        },
+    )
+    config.update({"id": "test_presence", "alias": "Test presence"})
+    assert await async_setup_component(hass, "automation", {"automation": [config]})
+
+    hass.states.async_set(occupancy, "on")
+    await hass.async_block_till_done()
+
+    assert len(mode_calls) == 1
+    assert mode_calls[0].data["hvac_mode"] == "auto"
+    assert len(temperature_calls) == 1
+    assert temperature_calls[0].data["temperature"] == 20.5
+
+    hass.states.async_set(occupancy, "off")
+    await hass.async_block_till_done()
+    assert len(off_calls) == 1
+    await hass.services.async_call(
+        "automation",
+        "turn_off",
+        {"entity_id": "automation.test_presence"},
+        blocking=True,
+    )
+
+
+async def test_back_to_sleep_blueprint_adjusts_then_restores(
+    hass: HomeAssistant,
+) -> None:
+    """An overnight absence and return applies the signed temporary adjustment."""
+    mode_calls = async_mock_service(hass, "climate", "set_hvac_mode")
+    temperature_calls = async_mock_service(hass, "climate", "set_temperature")
+    occupancy = "binary_sensor.sleepme_user_detected"
+    dock = "climate.sleepme_dock"
+    hass.states.async_set(occupancy, "on")
+    hass.states.async_set(dock, "auto", {"temperature": 20.0})
+    config = _substituted_config(
+        "dock_back_to_sleep.yaml",
+        {
+            "active_start_time": "00:00:00",
+            "active_end_time": "23:59:59",
+            "minimum_absence": {"seconds": 0},
+            "return_timeout": {"minutes": 1},
+            "temperature_adjustment": -1.5,
+            "adjustment_duration": {"seconds": 0},
+        },
+    )
+    config.update({"id": "test_return", "alias": "Test return"})
+    assert await async_setup_component(hass, "automation", {"automation": [config]})
+
+    hass.states.async_set(occupancy, "off")
+    # Let the automation reach wait_for_trigger without waiting on its timeout.
+    for _ in range(5):
+        await asyncio.sleep(0)
+    hass.states.async_set(occupancy, "on")
+    await hass.async_block_till_done()
+
+    assert len(mode_calls) == 1
+    assert [call.data["temperature"] for call in temperature_calls] == [18.5, 20.0]
+
+
+async def test_report_alert_blueprint_builds_action_message(
+    hass: HomeAssistant,
+) -> None:
+    """Missed thresholds are rendered into the public action template variable."""
+    alert_calls = async_mock_service(hass, "test", "alert")
+    states = {
+        "sensor.sleepme_last_report": "2026-07-11",
+        "sensor.sleepme_score": "60",
+        "sensor.sleepme_duration": "21600",
+        "sensor.sleepme_efficiency": "75",
+        "sensor.sleepme_latency": "2700",
+        "sensor.sleepme_deep_sleep": "8",
+    }
+    for entity_id, state in states.items():
+        hass.states.async_set(entity_id, state)
+    config = _substituted_config(
+        "sleep_report_alert.yaml",
+        {
+            "evaluation_delay": {"seconds": 0},
+            "alert_actions": [
+                {
+                    "action": "test.alert",
+                    "data": {"message": "{{ sleepme_alert_message }}"},
+                }
+            ],
+        },
+    )
+    config.update({"id": "test_report_alert", "alias": "Test report alert"})
+    assert await async_setup_component(hass, "automation", {"automation": [config]})
+
+    hass.states.async_set("sensor.sleepme_last_report", "2026-07-12")
+    await hass.async_block_till_done()
+
+    assert len(alert_calls) == 1
+    message = alert_calls[0].data["message"]
+    assert "sleep score 60" in message
+    assert "sleep duration 6.0 h" in message
+    assert "efficiency 75" in message
+    assert "latency 45" in message
+    assert "deep sleep 8" in message
+
+
+async def test_entity_translations_fall_back_for_every_ha_language(
+    hass: HomeAssistant,
+) -> None:
+    """Every frontend locale resolves new entity names through English fallback."""
+    key = f"component.{DOMAIN}.entity.sensor.sleep_efficiency_percent.name"
+    for language in LANGUAGES:
+        strings = await translation.async_get_translations(
+            hass, language, "entity", {DOMAIN}
+        )
+        assert strings[key] == "Sleep Efficiency", language

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
+from datetime import timedelta
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from custom_components.sleepme_thermostat.const import DOMAIN
@@ -17,12 +20,17 @@ from homeassistant.core import HomeAssistant
 from homeassistant.generated.languages import LANGUAGES
 from homeassistant.helpers import translation
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 from homeassistant.util import yaml as yaml_util
-from pytest_homeassistant_custom_component.common import async_mock_service
+from pytest_homeassistant_custom_component.common import (
+    async_fire_time_changed,
+    async_mock_service,
+)
 
 BLUEPRINTS = (
     Path(__file__).parents[1] / "blueprints" / "automation" / "sleepme_thermostat"
 )
+STRINGS = Path(__file__).parents[1] / "custom_components" / DOMAIN / "strings.json"
 
 BLUEPRINT_INPUTS = {
     "tracker_occupancy_actions.yaml": {
@@ -33,6 +41,10 @@ BLUEPRINT_INPUTS = {
         "dock_climate": "climate.sleepme_dock",
     },
     "dock_back_to_sleep.yaml": {
+        "occupancy_sensor": "binary_sensor.sleepme_user_detected",
+        "dock_climate": "climate.sleepme_dock",
+    },
+    "tracker_warm_awake.yaml": {
         "occupancy_sensor": "binary_sensor.sleepme_user_detected",
         "dock_climate": "climate.sleepme_dock",
     },
@@ -167,6 +179,44 @@ async def test_presence_control_blueprint_starts_and_stops_dock(
     )
 
 
+async def test_presence_control_extends_an_occupied_wake_time(
+    hass: HomeAssistant,
+) -> None:
+    """An occupied bed delays scheduled shutdown by the configured extension."""
+    off_calls = async_mock_service(hass, "climate", "turn_off")
+    occupancy = "binary_sensor.sleepme_user_detected"
+    await hass.config.async_set_time_zone("UTC")
+    trigger_time = (dt_util.utcnow() + timedelta(minutes=1)).replace(
+        second=0, microsecond=0
+    )
+    hass.states.async_set(occupancy, "on")
+    config = _substituted_config(
+        "dock_presence_control.yaml",
+        {
+            "sleep_end_time": trigger_time.strftime("%H:%M:%S"),
+            "occupied_wake_extension": {"minutes": 1},
+        },
+    )
+    config.update({"id": "test_snooze", "alias": "Test snooze"})
+    assert await async_setup_component(hass, "automation", {"automation": [config]})
+
+    async_fire_time_changed(hass, trigger_time + timedelta(seconds=1), fire_all=True)
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert not off_calls
+
+    async_fire_time_changed(hass, trigger_time + timedelta(seconds=62))
+    await hass.async_block_till_done()
+    await hass.services.async_call(
+        "automation",
+        "turn_off",
+        {"entity_id": "automation.test_snooze"},
+        blocking=True,
+    )
+
+    assert len(off_calls) == 1
+
+
 async def test_back_to_sleep_blueprint_adjusts_then_restores(
     hass: HomeAssistant,
 ) -> None:
@@ -200,6 +250,56 @@ async def test_back_to_sleep_blueprint_adjusts_then_restores(
 
     assert len(mode_calls) == 1
     assert [call.data["temperature"] for call in temperature_calls] == [18.5, 20.0]
+
+
+async def test_warm_awake_blueprint_heats_occupied_bed_then_stops(
+    hass: HomeAssistant,
+) -> None:
+    """Warm Awake starts at the configured offset and ends after its duration."""
+    mode_calls = async_mock_service(hass, "climate", "set_hvac_mode")
+    temperature_calls = async_mock_service(hass, "climate", "set_temperature")
+    off_calls = async_mock_service(hass, "climate", "turn_off")
+    occupancy = "binary_sensor.sleepme_user_detected"
+    dock = "climate.sleepme_dock"
+    await hass.config.async_set_time_zone("UTC")
+    trigger_time = (dt_util.utcnow() + timedelta(minutes=1)).replace(
+        second=0, microsecond=0
+    )
+    wake_time = (trigger_time + timedelta(minutes=15)).strftime("%H:%M:%S")
+    hass.states.async_set(occupancy, "on")
+    hass.states.async_set(dock, "auto", {"temperature": 20.0})
+    config = _substituted_config(
+        "tracker_warm_awake.yaml",
+        {
+            "wake_time": wake_time,
+            "preheat_minutes": 15,
+            "warm_temperature": 32.0,
+            "warm_duration": {"seconds": 0},
+        },
+    )
+    config.update({"id": "test_warm_awake", "alias": "Test warm awake"})
+    assert await async_setup_component(hass, "automation", {"automation": [config]})
+
+    # The time-pattern listener preserves its setup microseconds; advance one
+    # second into the target minute so the scheduled callback is due.
+    with patch("homeassistant.util.dt.now", return_value=trigger_time):
+        async_fire_time_changed(
+            hass, trigger_time + timedelta(seconds=1), fire_all=True
+        )
+        await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "automation",
+        "turn_off",
+        {"entity_id": "automation.test_warm_awake"},
+        blocking=True,
+    )
+
+    assert len(mode_calls) == 1
+    assert mode_calls[0].data["hvac_mode"] == "auto"
+    assert len(temperature_calls) == 1
+    assert temperature_calls[0].data["temperature"] == 32.0
+    assert len(off_calls) == 1
 
 
 async def test_report_alert_blueprint_builds_action_message(
@@ -244,13 +344,65 @@ async def test_report_alert_blueprint_builds_action_message(
     assert "deep sleep 8" in message
 
 
+async def test_report_alert_skips_incomplete_sensor_updates(
+    hass: HomeAssistant,
+) -> None:
+    """Unavailable report metrics never produce a false threshold alert."""
+    alert_calls = async_mock_service(hass, "test", "alert")
+    states = {
+        "sensor.sleepme_last_report": "2026-07-11",
+        "sensor.sleepme_score": "unavailable",
+        "sensor.sleepme_duration": "unavailable",
+        "sensor.sleepme_efficiency": "unavailable",
+        "sensor.sleepme_latency": "unavailable",
+        "sensor.sleepme_deep_sleep": "unavailable",
+    }
+    for entity_id, state in states.items():
+        hass.states.async_set(entity_id, state)
+    config = _substituted_config(
+        "sleep_report_alert.yaml",
+        {
+            "evaluation_delay": {"seconds": 0},
+            "alert_actions": [{"action": "test.alert"}],
+        },
+    )
+    config.update({"id": "test_incomplete_report", "alias": "Test incomplete"})
+    assert await async_setup_component(hass, "automation", {"automation": [config]})
+
+    hass.states.async_set("sensor.sleepme_last_report", "2026-07-12")
+    await hass.async_block_till_done()
+
+    assert not alert_calls
+
+
 async def test_entity_translations_fall_back_for_every_ha_language(
     hass: HomeAssistant,
 ) -> None:
-    """Every frontend locale resolves new entity names through English fallback."""
-    key = f"component.{DOMAIN}.entity.sensor.sleep_efficiency_percent.name"
+    """Every frontend locale resolves every report entity and option string."""
+    source_strings = json.loads(STRINGS.read_text())
+    entity_names = {
+        f"component.{DOMAIN}.entity.sensor.{key}.name": value["name"]
+        for key, value in source_strings["entity"]["sensor"].items()
+    }
+    required_option_keys = {
+        f"component.{DOMAIN}.options.step.init.title",
+        f"component.{DOMAIN}.options.step.init.description",
+        f"component.{DOMAIN}.options.step.init.data.scan_interval",
+        f"component.{DOMAIN}.options.step.init.data.sleep_target_hours",
+        f"component.{DOMAIN}.options.error.invalid_scan_interval",
+        f"component.{DOMAIN}.options.error.invalid_sleep_target",
+    }
+
     for language in LANGUAGES:
-        strings = await translation.async_get_translations(
+        entity_strings = await translation.async_get_translations(
             hass, language, "entity", {DOMAIN}
         )
-        assert strings[key] == "Sleep Efficiency", language
+        assert {key: entity_strings.get(key) for key in entity_names} == entity_names, (
+            language
+        )
+
+        option_strings = await translation.async_get_translations(
+            hass, language, "options", {DOMAIN}
+        )
+        assert required_option_keys <= option_strings.keys(), language
+        assert all(option_strings[key] for key in required_option_keys), language

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -31,6 +31,7 @@ BLUEPRINTS = (
     Path(__file__).parents[1] / "blueprints" / "automation" / "sleepme_thermostat"
 )
 STRINGS = Path(__file__).parents[1] / "custom_components" / DOMAIN / "strings.json"
+TRANSLATIONS = STRINGS.parent / "translations"
 
 BLUEPRINT_INPUTS = {
     "tracker_occupancy_actions.yaml": {
@@ -63,6 +64,19 @@ BLUEPRINT_INPUTS = {
         ],
     },
 }
+
+
+def _flatten_strings(data: dict, prefix: str = "") -> dict[str, str]:
+    """Flatten nested translation strings into dotted leaf paths."""
+    flattened: dict[str, str] = {}
+    for key, value in data.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            flattened.update(_flatten_strings(value, path))
+        else:
+            assert isinstance(value, str), path
+            flattened[path] = value
+    return flattened
 
 
 def _substituted_config(filename: str, overrides: dict | None = None) -> dict:
@@ -378,12 +392,8 @@ async def test_report_alert_skips_incomplete_sensor_updates(
 async def test_entity_translations_fall_back_for_every_ha_language(
     hass: HomeAssistant,
 ) -> None:
-    """Every frontend locale resolves every report entity and option string."""
+    """Every frontend locale resolves localized or fallback integration strings."""
     source_strings = json.loads(STRINGS.read_text())
-    entity_names = {
-        f"component.{DOMAIN}.entity.sensor.{key}.name": value["name"]
-        for key, value in source_strings["entity"]["sensor"].items()
-    }
     required_option_keys = {
         f"component.{DOMAIN}.options.step.init.title",
         f"component.{DOMAIN}.options.step.init.description",
@@ -394,6 +404,17 @@ async def test_entity_translations_fall_back_for_every_ha_language(
     }
 
     for language in LANGUAGES:
+        localized_entities = source_strings["entity"]["sensor"]
+        locale_path = TRANSLATIONS / f"{language}.json"
+        if locale_path.exists():
+            locale_strings = json.loads(locale_path.read_text())
+            localized_entities = locale_strings.get("entity", {}).get(
+                "sensor", localized_entities
+            )
+        entity_names = {
+            f"component.{DOMAIN}.entity.sensor.{key}.name": value["name"]
+            for key, value in localized_entities.items()
+        }
         entity_strings = await translation.async_get_translations(
             hass, language, "entity", {DOMAIN}
         )
@@ -406,3 +427,34 @@ async def test_entity_translations_fall_back_for_every_ha_language(
         )
         assert required_option_keys <= option_strings.keys(), language
         assert all(option_strings[key] for key in required_option_keys), language
+
+
+async def test_hungarian_translations_are_complete_and_native(
+    hass: HomeAssistant,
+) -> None:
+    """Hungarian covers every source leaf and is loaded by HA without fallback."""
+    assert "hu" in LANGUAGES
+    source_strings = json.loads(STRINGS.read_text())
+    hungarian = json.loads((TRANSLATIONS / "hu.json").read_text())
+
+    assert _flatten_strings(hungarian).keys() == _flatten_strings(source_strings).keys()
+    assert all(_flatten_strings(hungarian).values())
+    assert hungarian["config"]["step"]["user"]["title"] == ("SleepMe-eszköz hozzáadása")
+    assert hungarian["entity"]["sensor"]["sleep_debt"]["name"] == "Alvásadósság"
+    assert hungarian["services"]["get_sleep_reports"]["name"] == (
+        "Alvásjelentések lekérése"
+    )
+
+    for category in ("title", "config", "entity", "options", "services"):
+        category_data = hungarian[category]
+        if isinstance(category_data, str):
+            expected = {f"component.{DOMAIN}.{category}": category_data}
+        else:
+            expected = {
+                f"component.{DOMAIN}.{category}.{key}": value
+                for key, value in _flatten_strings(category_data).items()
+            }
+        loaded = await translation.async_get_translations(
+            hass, "hu", category, {DOMAIN}
+        )
+        assert {key: loaded.get(key) for key in expected} == expected

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,6 +8,7 @@ import pytest
 from custom_components.sleepme_thermostat.const import (
     API_URL,
     CONF_SCAN_INTERVAL,
+    CONF_SLEEP_TARGET_HOURS,
     DOMAIN,
 )
 from custom_components.sleepme_thermostat.sleepme_api import (
@@ -308,6 +309,24 @@ def _entry_with_default_options() -> MockConfigEntry:
     )
 
 
+def _tracker_entry_with_default_options() -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="entry_tracker_opts",
+        version=5,
+        unique_id="tracker-options-device",
+        title="Sleep Tracker Bedroom",
+        data={
+            "api_token": MOCK_API_TOKEN,
+            "device_id": "tracker-options-device",
+            "firmware_version": "2.3.4",
+            "mac_address": "11:22:33:44:55:66",
+            "model": "ST501NA",
+            "serial_number": "TRACKER-OPTIONS",
+        },
+    )
+
+
 async def test_options_flow_happy_path(
     hass: HomeAssistant, mock_sleepme_client: AsyncMock
 ) -> None:
@@ -360,3 +379,49 @@ async def test_options_flow_rejects_out_of_range(
     )
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {CONF_SCAN_INTERVAL: "invalid_scan_interval"}
+
+
+async def test_tracker_options_include_sleep_target(
+    hass: HomeAssistant,
+    mock_sleepme_client: AsyncMock,
+    tracker_status: dict,
+) -> None:
+    """Tracker options persist the goal used for derived sleep-debt sensors."""
+    mock_sleepme_client.get_device_status.return_value = tracker_status
+    entry = _tracker_entry_with_default_options()
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_SCAN_INTERVAL: 30, CONF_SLEEP_TARGET_HOURS: 7.5},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_SLEEP_TARGET_HOURS] == 7.5
+
+
+async def test_tracker_options_reject_invalid_sleep_target(
+    hass: HomeAssistant,
+    mock_sleepme_client: AsyncMock,
+    tracker_status: dict,
+) -> None:
+    """The configurable target is bounded to a plausible 4-12 hours."""
+    mock_sleepme_client.get_device_status.return_value = tracker_status
+    entry = _tracker_entry_with_default_options()
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_SCAN_INTERVAL: 30, CONF_SLEEP_TARGET_HOURS: 3.75},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_SLEEP_TARGET_HOURS: "invalid_sleep_target"}
+    assert CONF_SLEEP_TARGET_HOURS not in entry.options

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -16,6 +16,7 @@ from custom_components.sleepme_thermostat.sleepme_api import (
     SleepMeConnectionError,
 )
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
+from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -395,6 +396,11 @@ async def test_tracker_options_include_sleep_target(
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
     assert result["type"] is FlowResultType.FORM
+    option_selectors = list(result["data_schema"].schema.values())
+    assert [option.config["unit_of_measurement"] for option in option_selectors] == [
+        UnitOfTime.SECONDS,
+        UnitOfTime.HOURS,
+    ]
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {CONF_SCAN_INTERVAL: 30, CONF_SLEEP_TARGET_HOURS: 7.5},

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -106,6 +106,38 @@ async def test_select_device_accepts_gen2(
     mock_flow_client.get_device_status.assert_called_once()
 
 
+async def test_select_device_recognizes_sleep_tracker(
+    hass: HomeAssistant, mock_flow_client: AsyncMock
+) -> None:
+    """ST501NA is configured as a Sleep Tracker instead of a Dock Pro."""
+    tracker_id = "st-tracker-device"
+    mock_flow_client.get_claimed_devices.return_value = [
+        {"id": tracker_id, "name": "Bedroom"}
+    ]
+    mock_flow_client.get_device_status.return_value = {
+        "about": {
+            "firmware_version": "2.3.4",
+            "mac_address": "11:22:33:44:55:66",
+            "model": "ST501NA",
+            "serial_number": "TRACKER-1",
+        }
+    }
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"api_token": MOCK_API_TOKEN}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"device_id": tracker_id}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Sleep Tracker Bedroom"
+    assert result["data"]["model"] == "ST501NA"
+
+
 async def test_user_step_invalid_token(
     hass: HomeAssistant, mock_flow_client: AsyncMock
 ) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -12,6 +13,7 @@ from custom_components.sleepme_thermostat.sleepme_api import (
     SleepMeConnectionError,
     SleepMeRateLimited,
 )
+from custom_components.sleepme_thermostat.update_manager import _report_windows
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -38,6 +40,17 @@ def _entry() -> MockConfigEntry:
             "serial_number": "TEST-SERIAL",
         },
     )
+
+
+def test_report_windows_cover_thirty_days_without_overlap() -> None:
+    """The API's seven-date cap is paged into one exact 30-day range."""
+    assert _report_windows(date(2026, 7, 13), 30) == [
+        (date(2026, 7, 13), 6),
+        (date(2026, 7, 6), 6),
+        (date(2026, 6, 29), 6),
+        (date(2026, 6, 22), 6),
+        (date(2026, 6, 15), 1),
+    ]
 
 
 @pytest.fixture

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -62,13 +62,19 @@ async def test_diagnostics_structure(
 
     diag = await async_get_config_entry_diagnostics(hass, entry)
 
-    assert set(diag.keys()) == {"entry", "device_info", "coordinator"}
-    assert diag["entry"]["version"] == 4
+    assert set(diag.keys()) == {
+        "entry",
+        "device_info",
+        "coordinator",
+        "report_coordinator",
+    }
+    assert diag["entry"]["version"] == 5
     assert diag["entry"]["title"] == f"Dock Pro {MOCK_NAME}"
     assert diag["entry"]["options"]["scan_interval"] == 30
     assert diag["coordinator"]["last_update_success"] is True
     assert diag["coordinator"]["update_interval_seconds"] == 30
     assert set(diag["coordinator"]["data"].keys()) == {"status", "control", "about"}
+    assert diag["report_coordinator"] is None
 
 
 async def test_diagnostics_handles_missing_entry_data(
@@ -84,3 +90,42 @@ async def test_diagnostics_handles_missing_entry_data(
 
     assert diag["entry"]["data"]["api_token"] == "**REDACTED**"
     assert diag["coordinator"] == {}
+    assert diag["report_coordinator"] is None
+
+
+async def test_tracker_diagnostics_never_include_health_payload(
+    hass: HomeAssistant,
+    mock_sleepme_client: AsyncMock,
+    tracker_status: dict,
+) -> None:
+    """Support bundles expose report health/counts but no sessions or hypnograms."""
+    mock_sleepme_client.get_device_status.return_value = tracker_status
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="entry_tracker_diag",
+        version=5,
+        unique_id="tracker-device",
+        title="Sleep Tracker Bedroom",
+        data={
+            "api_token": MOCK_API_TOKEN,
+            "device_id": "tracker-device",
+            "firmware_version": "2.3.4-test",
+            "mac_address": "11:22:33:44:55:66",
+            "model": "ST501NA",
+            "serial_number": "TRACKER-TEST-SERIAL",
+        },
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diag["report_coordinator"] == {
+        "update_interval_seconds": 1800,
+        "last_update_success": True,
+        "last_exception": None,
+        "report_count": 3,
+    }
+    assert "sessions" not in str(diag["report_coordinator"])
+    assert "hypnogram" not in str(diag["report_coordinator"])

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from unittest.mock import AsyncMock
 
 from custom_components.sleepme_thermostat.const import API_URL, DOMAIN
+from custom_components.sleepme_thermostat.sleepme_api import (
+    SleepMeAuthError,
+    SleepMeConnectionError,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -115,9 +119,9 @@ async def test_tracker_entry_loads_all_live_and_report_entities(
     assert state_for("sensor", "sleep_report_total_sleep_duration").state == "31200"
     assert state_for("sensor", "sleep_report_hypnogram_segment_count").state == "7"
     assert state_for("sensor", "sleep_report_sleep_efficiency_percent").state == (
-        "89.1"
+        "89.0"
     )
-    assert state_for("sensor", "sleep_report_wake_after_sleep_onset").state == "2400"
+    assert state_for("sensor", "sleep_report_wake_after_sleep_onset").state == "2460"
     assert state_for("sensor", "sleep_report_deep_sleep_percent").state == "25.0"
     assert state_for("sensor", "sleep_report_awakening_count").state == "0"
     assert (
@@ -147,6 +151,87 @@ async def test_tracker_entry_loads_all_live_and_report_entities(
             f"{DOMAIN}_{device_id}_thermostat",
         )
         is None
+    )
+
+
+async def test_tracker_live_entities_survive_report_endpoint_failure(
+    hass: HomeAssistant,
+    mock_sleepme_client: AsyncMock,
+    tracker_status: dict,
+) -> None:
+    """A transient report outage does not hide live occupancy/environment data."""
+    mock_sleepme_client.get_device_status.return_value = tracker_status
+    mock_sleepme_client.get_sleep_reports.side_effect = SleepMeConnectionError(
+        "temporary report outage"
+    )
+    device_id = "tracker-report-outage"
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="entry_tracker_report_outage",
+        version=5,
+        unique_id=device_id,
+        title="Sleep Tracker Resilient",
+        data={
+            "api_token": MOCK_API_TOKEN,
+            "device_id": device_id,
+            "firmware_version": "2.3.4-test",
+            "mac_address": "11:22:33:44:55:66",
+            "model": "ST501NA",
+            "serial_number": "TRACKER-TEST-SERIAL",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.runtime_data.report_coordinator is not None
+    assert entry.runtime_data.report_coordinator.last_update_success is False
+    registry = er.async_get(hass)
+    occupancy_id = registry.async_get_entity_id(
+        "binary_sensor", DOMAIN, f"{DOMAIN}_{device_id}_user_detected"
+    )
+    report_id = registry.async_get_entity_id(
+        "sensor", DOMAIN, f"{DOMAIN}_{device_id}_sleep_report_date"
+    )
+    assert occupancy_id is not None
+    assert hass.states.get(occupancy_id).state == "on"
+    assert report_id is not None
+    assert hass.states.get(report_id).state == "unavailable"
+
+
+async def test_tracker_report_auth_failure_still_triggers_reauth(
+    hass: HomeAssistant,
+    mock_sleepme_client: AsyncMock,
+    tracker_status: dict,
+) -> None:
+    """Report authentication failures are never hidden by outage isolation."""
+    mock_sleepme_client.get_device_status.return_value = tracker_status
+    mock_sleepme_client.get_sleep_reports.side_effect = SleepMeAuthError(
+        "revoked token"
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="entry_tracker_report_auth",
+        version=5,
+        unique_id="tracker-report-auth",
+        title="Sleep Tracker Auth",
+        data={
+            "api_token": MOCK_API_TOKEN,
+            "device_id": "tracker-report-auth",
+            "model": "ST501NA",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert any(
+        flow["context"].get("source") == "reauth"
+        for flow in hass.config_entries.flow.async_progress_by_handler(DOMAIN)
     )
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 from custom_components.sleepme_thermostat.const import API_URL, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -51,6 +52,73 @@ async def test_setup_entry_loads(
     assert entry.state is ConfigEntryState.LOADED
     assert entry.runtime_data is not None
     assert entry.runtime_data.coordinator is not None
+    assert entry.runtime_data.report_coordinator is None
+
+
+async def test_tracker_entry_loads_all_live_and_report_entities(
+    hass: HomeAssistant,
+    mock_sleepme_client: AsyncMock,
+    tracker_status: dict,
+) -> None:
+    """ST501NA gets tracker entities, report entities, and no climate entity."""
+    mock_sleepme_client.get_device_status.return_value = tracker_status
+    device_id = "tracker-device"
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="entry_tracker",
+        version=5,
+        unique_id=device_id,
+        title="Sleep Tracker Bedroom",
+        data={
+            "api_token": MOCK_API_TOKEN,
+            "device_id": device_id,
+            "firmware_version": "2.3.4-test",
+            "mac_address": "11:22:33:44:55:66",
+            "model": "ST501NA",
+            "serial_number": "TRACKER-TEST-SERIAL",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.runtime_data.report_coordinator is not None
+    assert entry.runtime_data.report_coordinator.last_update_success is True
+
+    registry = er.async_get(hass)
+
+    def state_for(platform: str, unique_suffix: str):
+        entity_id = registry.async_get_entity_id(
+            platform,
+            DOMAIN,
+            f"{DOMAIN}_{device_id}_{unique_suffix}",
+        )
+        assert entity_id is not None
+        state = hass.states.get(entity_id)
+        assert state is not None
+        return state
+
+    assert state_for("binary_sensor", "connected").state == "on"
+    assert state_for("binary_sensor", "user_detected").state == "on"
+    assert state_for("sensor", "environment_humidity").state == "47.5"
+    assert state_for("sensor", "environment_temperature").state == "21.5"
+    assert state_for("sensor", "bed_temperature").state == "28.0"
+    assert state_for("sensor", "sleep_report_date").state == "2026-07-12"
+    assert state_for("sensor", "sleep_report_sleep_score_percent").state == "88"
+    assert state_for("sensor", "sleep_report_session_count").state == "2"
+    assert state_for("sensor", "sleep_report_total_sleep_duration").state == "31200"
+    assert state_for("sensor", "sleep_report_hypnogram_segment_count").state == "7"
+
+    assert (
+        registry.async_get_entity_id(
+            "climate",
+            DOMAIN,
+            f"{DOMAIN}_{device_id}_thermostat",
+        )
+        is None
+    )
 
 
 async def test_unload_entry(
@@ -103,10 +171,10 @@ async def test_multi_entry_isolation(
     assert entry_b.runtime_data is not None
 
 
-async def test_migrate_entry_v3_to_v4(
+async def test_migrate_entry_v3_to_v5(
     hass: HomeAssistant, mock_sleepme_client: AsyncMock
 ) -> None:
-    """A v3 entry auto-migrates to v4: api_url and name removed; version bumps."""
+    """A v3 entry reaches v5 with obsolete fields removed."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         entry_id="entry_v3",
@@ -130,10 +198,41 @@ async def test_migrate_entry_v3_to_v4(
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.LOADED
-    assert entry.version == 4
+    assert entry.version == 5
     assert "api_url" not in entry.data
     assert "name" not in entry.data
     # Other keys survive untouched.
     assert entry.data["device_id"] == MOCK_DEVICE_ID
     assert entry.data["api_token"] == MOCK_API_TOKEN
     assert entry.title == f"Dock Pro {MOCK_NAME}"
+
+
+async def test_migrate_tracker_entry_retitles_device(
+    hass: HomeAssistant,
+    mock_sleepme_client: AsyncMock,
+    tracker_status: dict,
+) -> None:
+    """A tracker configured before v5 loses the misleading Dock Pro title."""
+    mock_sleepme_client.get_device_status.return_value = tracker_status
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="entry_old_tracker",
+        version=4,
+        unique_id="tracker-device",
+        title="Dock Pro Bedroom",
+        data={
+            "api_token": MOCK_API_TOKEN,
+            "device_id": "tracker-device",
+            "firmware_version": "2.3.4-test",
+            "mac_address": "11:22:33:44:55:66",
+            "model": "ST501NA",
+            "serial_number": "TRACKER-TEST-SERIAL",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.version == 5
+    assert entry.title == "Sleep Tracker Bedroom"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -61,6 +61,9 @@ async def test_tracker_entry_loads_all_live_and_report_entities(
     tracker_status: dict,
 ) -> None:
     """ST501NA gets tracker entities, report entities, and no climate entity."""
+    # German is intentionally not bundled: HA must resolve the English source
+    # fallback, proving unsupported integration locales remain fully usable.
+    hass.config.language = "de"
     mock_sleepme_client.get_device_status.return_value = tracker_status
     device_id = "tracker-device"
     entry = MockConfigEntry(
@@ -77,6 +80,7 @@ async def test_tracker_entry_loads_all_live_and_report_entities(
             "model": "ST501NA",
             "serial_number": "TRACKER-TEST-SERIAL",
         },
+        options={"sleep_target_hours": 10.0},
     )
     entry.add_to_hass(hass)
 
@@ -110,6 +114,31 @@ async def test_tracker_entry_loads_all_live_and_report_entities(
     assert state_for("sensor", "sleep_report_session_count").state == "2"
     assert state_for("sensor", "sleep_report_total_sleep_duration").state == "31200"
     assert state_for("sensor", "sleep_report_hypnogram_segment_count").state == "7"
+    assert state_for("sensor", "sleep_report_sleep_efficiency_percent").state == (
+        "89.1"
+    )
+    assert state_for("sensor", "sleep_report_wake_after_sleep_onset").state == "2400"
+    assert state_for("sensor", "sleep_report_deep_sleep_percent").state == "25.0"
+    assert state_for("sensor", "sleep_report_awakening_count").state == "0"
+    assert (
+        state_for("sensor", "sleep_report_longest_uninterrupted_sleep_duration").state
+        == "27900"
+    )
+    assert state_for("sensor", "sleep_report_nap_count").state == "1"
+    assert state_for("sensor", "sleep_report_sleep_debt").state == "4800.0"
+    assert state_for("sensor", "sleep_report_sleep_goal_percent").state == "86.7"
+    assert state_for("sensor", "sleep_report_tracked_nights_7d").state == "2"
+    assert (
+        state_for("sensor", "sleep_report_average_sleep_score_percent_30d").state
+        == "84.0"
+    )
+    assert state_for("sensor", "sleep_report_bedtime_consistency_7d").state == ("15.0")
+    assert (
+        state_for("sensor", "sleep_report_sleep_efficiency_percent").attributes[
+            "friendly_name"
+        ]
+        == "Sleep Tracker Bedroom Sleep Efficiency"
+    )
 
     assert (
         registry.async_get_entity_id(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,91 @@
+"""Tests for the lossless on-demand sleep-report action."""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import AsyncMock
+
+import pytest
+from custom_components.sleepme_thermostat.const import (
+    ATTR_CONFIG_ENTRY_ID,
+    ATTR_DAYS_BACK,
+    ATTR_START_DATE,
+    ATTR_TIME_ZONE,
+    DOMAIN,
+    SERVICE_GET_SLEEP_REPORTS,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from tests.const import MOCK_API_TOKEN
+
+
+def _tracker_entry() -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="entry_tracker_service",
+        version=5,
+        unique_id="tracker-device",
+        title="Sleep Tracker Bedroom",
+        data={
+            "api_token": MOCK_API_TOKEN,
+            "device_id": "tracker-device",
+            "firmware_version": "2.3.4-test",
+            "mac_address": "11:22:33:44:55:66",
+            "model": "ST501NA",
+            "serial_number": "TRACKER-TEST-SERIAL",
+        },
+    )
+
+
+async def test_get_sleep_reports_returns_raw_payload(
+    hass: HomeAssistant,
+    mock_sleepme_client: AsyncMock,
+    tracker_status: dict,
+    sleep_reports: list[dict],
+) -> None:
+    """The response action preserves sessions and hypnogram segments exactly."""
+    mock_sleepme_client.get_device_status.return_value = tracker_status
+    entry = _tracker_entry()
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_SLEEP_REPORTS,
+        {
+            ATTR_CONFIG_ENTRY_ID: entry.entry_id,
+            ATTR_START_DATE: "2026-07-13",
+            ATTR_DAYS_BACK: 6,
+            ATTR_TIME_ZONE: "Europe/Budapest",
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response == {"reports": sleep_reports}
+    call = mock_sleepme_client.get_sleep_reports.await_args
+    assert call.kwargs == {
+        "start_date": date(2026, 7, 13),
+        "days_back": 6,
+        "time_zone": "Europe/Budapest",
+    }
+
+
+async def test_get_sleep_reports_rejects_unknown_entry(
+    hass: HomeAssistant,
+) -> None:
+    """An explicit loaded config entry is required for predictable routing."""
+    from custom_components.sleepme_thermostat import async_setup
+
+    await async_setup(hass, {})
+    with pytest.raises(ServiceValidationError, match="not found"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_GET_SLEEP_REPORTS,
+            {ATTR_CONFIG_ENTRY_ID: "missing-entry"},
+            blocking=True,
+            return_response=True,
+        )

--- a/tests/test_sleep_reports.py
+++ b/tests/test_sleep_reports.py
@@ -27,13 +27,13 @@ def test_summary_aggregates_every_session(sleep_reports: list[dict]) -> None:
     assert summary["sleep_score_percent"] == 88
     assert summary["session_count"] == 2
     assert summary["total_session_duration"] == 36000
-    assert summary["in_bed_duration"] == 35000
+    assert summary["in_bed_duration"] == 35040
     assert summary["total_sleep_duration"] == 31200
-    assert summary["awake_duration"] == 3800
+    assert summary["awake_duration"] == 3840
     assert summary["light_sleep_duration"] == 15600
     assert summary["rem_sleep_duration"] == 7800
     assert summary["deep_sleep_duration"] == 7800
-    assert summary["sleep_latency"] == 1400
+    assert summary["sleep_latency"] == 1380
     assert summary["hypnogram_segment_count"] == 7
     assert summary["enter_bed_time"] == datetime.fromisoformat(
         "2026-07-12T14:00:00+02:00"
@@ -41,9 +41,9 @@ def test_summary_aggregates_every_session(sleep_reports: list[dict]) -> None:
     assert summary["exit_bed_time"] == datetime.fromisoformat(
         "2026-07-13T07:00:00+02:00"
     )
-    assert summary["sleep_efficiency_percent"] == 89.1
-    assert summary["wake_after_sleep_onset"] == 2400
-    assert summary["awake_percent"] == 10.9
+    assert summary["sleep_efficiency_percent"] == 89.0
+    assert summary["wake_after_sleep_onset"] == 2460
+    assert summary["awake_percent"] == 11.0
     assert summary["light_sleep_percent"] == 50.0
     assert summary["rem_sleep_percent"] == 25.0
     assert summary["deep_sleep_percent"] == 25.0
@@ -78,6 +78,38 @@ def test_summary_uses_configurable_sleep_target(
     assert summary["sleep_goal_percent"] == 86.7
 
 
+def test_public_api_minutes_are_normalized_to_ha_seconds() -> None:
+    """Raw report minutes become seconds before entities and formulas use them."""
+    summary = summarize_sleep_report(
+        {
+            "date": "2026-07-12",
+            "sessions": [
+                {
+                    "total_session_duration": 90,
+                    "in_bed_duration": 75,
+                    "total_sleep_duration": 60,
+                    "awake_duration": 15,
+                    "sleep_latency": 5,
+                    "hypnogram": {
+                        "segments": [
+                            {"start": 0, "end": 5, "stage": "AWAKE"},
+                            {"start": 5, "end": 65, "stage": "LIGHT_SLEEP"},
+                            {"start": 65, "end": 90, "stage": "NO_DATA"},
+                        ]
+                    },
+                }
+            ],
+        }
+    )
+
+    assert summary["total_session_duration"] == 5400
+    assert summary["total_sleep_duration"] == 3600
+    assert summary["sleep_latency"] == 300
+    assert summary["wake_after_sleep_onset"] == 600
+    assert summary["longest_uninterrupted_sleep_duration"] == 3600
+    assert summary["sleep_debt"] == 7 * 3600
+
+
 def test_history_summarizes_seven_and_thirty_days(
     sleep_reports: list[dict],
 ) -> None:
@@ -89,7 +121,7 @@ def test_history_summarizes_seven_and_thirty_days(
         assert history[f"average_sleep_score_percent_{suffix}"] == 84.0
         assert history[f"average_total_sleep_duration_{suffix}"] == 28200.0
         assert history[f"average_sleep_efficiency_percent_{suffix}"] == 89.2
-        assert history[f"average_sleep_latency_{suffix}"] == 1150.0
+        assert history[f"average_sleep_latency_{suffix}"] == 1140.0
         assert history[f"average_deep_sleep_percent_{suffix}"] == 25.0
         assert history[f"average_rem_sleep_percent_{suffix}"] == 25.0
         assert history[f"average_awakening_count_{suffix}"] == 0.0
@@ -104,19 +136,19 @@ def test_hypnogram_derives_awakenings_and_longest_run() -> None:
         "date": "2026-07-12",
         "sessions": [
             {
-                "total_sleep_duration": 300,
-                "in_bed_duration": 450,
-                "awake_duration": 150,
-                "sleep_latency": 50,
+                "total_sleep_duration": 5,
+                "in_bed_duration": 7.5,
+                "awake_duration": 2.5,
+                "sleep_latency": 50 / 60,
                 "hypnogram": {
                     "raw_hypnogram_segment_count": 6,
                     "segments": [
-                        {"start": 0, "end": 50, "stage": "AWAKE"},
-                        {"start": 50, "end": 150, "stage": "LIGHT_SLEEP"},
-                        {"start": 150, "end": 250, "stage": "REM_SLEEP"},
-                        {"start": 250, "end": 300, "stage": "AWAKE"},
-                        {"start": 300, "end": 400, "stage": "DEEP_SLEEP"},
-                        {"start": 450, "end": 440, "stage": "AWAKE"},
+                        {"start": 0, "end": 1, "stage": "AWAKE"},
+                        {"start": 1, "end": 2, "stage": "LIGHT_SLEEP"},
+                        {"start": 2, "end": 4, "stage": "REM_SLEEP"},
+                        {"start": 4, "end": 5, "stage": "AWAKE"},
+                        {"start": 5, "end": 7, "stage": "DEEP_SLEEP"},
+                        {"start": 8, "end": 7, "stage": "AWAKE"},
                     ],
                 },
             }
@@ -125,7 +157,7 @@ def test_hypnogram_derives_awakenings_and_longest_run() -> None:
 
     summary = summarize_sleep_report(report)
     assert summary["awakening_count"] == 1
-    assert summary["longest_uninterrupted_sleep_duration"] == 200
+    assert summary["longest_uninterrupted_sleep_duration"] == 180
 
 
 def test_undefined_percentages_and_malformed_shapes_are_safe() -> None:
@@ -154,7 +186,7 @@ def test_clock_consistency_wraps_across_midnight() -> None:
                 {
                     "enter_bed_time": entered,
                     "exit_bed_time": exited,
-                    "total_sleep_duration": 3600,
+                    "total_sleep_duration": 60,
                 }
             ],
         }

--- a/tests/test_sleep_reports.py
+++ b/tests/test_sleep_reports.py
@@ -1,0 +1,46 @@
+"""Tests for sleep-report selection and daily-session aggregation."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from custom_components.sleepme_thermostat.sleep_reports import (
+    latest_sleep_report,
+    summarize_sleep_report,
+)
+
+
+def test_latest_report_skips_empty_current_day(sleep_reports: list[dict]) -> None:
+    """An empty report for today does not hide the latest completed night."""
+    report = latest_sleep_report(sleep_reports)
+    assert report is not None
+    assert report["date"] == "2026-07-12"
+
+
+def test_summary_aggregates_every_session(sleep_reports: list[dict]) -> None:
+    """Naps and the main sleep session are represented in daily totals."""
+    summary = summarize_sleep_report(latest_sleep_report(sleep_reports))
+
+    assert summary["date"] == date(2026, 7, 12)
+    assert summary["sleep_score_percent"] == 88
+    assert summary["session_count"] == 2
+    assert summary["total_session_duration"] == 36000
+    assert summary["in_bed_duration"] == 35000
+    assert summary["total_sleep_duration"] == 31200
+    assert summary["awake_duration"] == 3800
+    assert summary["light_sleep_duration"] == 15600
+    assert summary["rem_sleep_duration"] == 7800
+    assert summary["deep_sleep_duration"] == 7800
+    assert summary["sleep_latency"] == 1400
+    assert summary["hypnogram_segment_count"] == 7
+    assert summary["enter_bed_time"] == datetime.fromisoformat(
+        "2026-07-12T14:00:00+02:00"
+    )
+    assert summary["exit_bed_time"] == datetime.fromisoformat(
+        "2026-07-13T07:00:00+02:00"
+    )
+
+
+def test_missing_report_returns_empty_summary() -> None:
+    assert latest_sleep_report([]) is None
+    assert summarize_sleep_report(None) == {}

--- a/tests/test_sleep_reports.py
+++ b/tests/test_sleep_reports.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from datetime import date, datetime
 
+import pytest
 from custom_components.sleepme_thermostat.sleep_reports import (
     latest_sleep_report,
+    summarize_sleep_history,
     summarize_sleep_report,
 )
 
@@ -39,6 +41,132 @@ def test_summary_aggregates_every_session(sleep_reports: list[dict]) -> None:
     assert summary["exit_bed_time"] == datetime.fromisoformat(
         "2026-07-13T07:00:00+02:00"
     )
+    assert summary["sleep_efficiency_percent"] == 89.1
+    assert summary["wake_after_sleep_onset"] == 2400
+    assert summary["awake_percent"] == 10.9
+    assert summary["light_sleep_percent"] == 50.0
+    assert summary["rem_sleep_percent"] == 25.0
+    assert summary["deep_sleep_percent"] == 25.0
+    assert summary["restorative_sleep_duration"] == 15600
+    assert summary["restorative_sleep_percent"] == 50.0
+    assert summary["sleep_debt"] == 0
+    assert summary["sleep_goal_percent"] == 108.3
+    assert summary["awakening_count"] == 0
+    assert summary["longest_uninterrupted_sleep_duration"] == 27900
+    assert summary["main_enter_bed_time"] == datetime.fromisoformat(
+        "2026-07-12T23:00:00+02:00"
+    )
+    assert summary["main_exit_bed_time"] == datetime.fromisoformat(
+        "2026-07-13T07:00:00+02:00"
+    )
+    assert summary["sleep_midpoint"] == datetime.fromisoformat(
+        "2026-07-13T03:00:00+02:00"
+    )
+    assert summary["nap_count"] == 1
+    assert summary["nap_sleep_duration"] == 6000
+
+
+def test_summary_uses_configurable_sleep_target(
+    sleep_reports: list[dict],
+) -> None:
+    """Debt and goal percentage reflect HA's option, not a vendor claim."""
+    summary = summarize_sleep_report(
+        latest_sleep_report(sleep_reports), sleep_target_seconds=10 * 3600
+    )
+
+    assert summary["sleep_debt"] == 4800
+    assert summary["sleep_goal_percent"] == 86.7
+
+
+def test_history_summarizes_seven_and_thirty_days(
+    sleep_reports: list[dict],
+) -> None:
+    """Rolling metrics include completed nights and skip today's empty shell."""
+    history = summarize_sleep_history(sleep_reports)
+
+    for suffix in ("7d", "30d"):
+        assert history[f"tracked_nights_{suffix}"] == 2
+        assert history[f"average_sleep_score_percent_{suffix}"] == 84.0
+        assert history[f"average_total_sleep_duration_{suffix}"] == 28200.0
+        assert history[f"average_sleep_efficiency_percent_{suffix}"] == 89.2
+        assert history[f"average_sleep_latency_{suffix}"] == 1150.0
+        assert history[f"average_deep_sleep_percent_{suffix}"] == 25.0
+        assert history[f"average_rem_sleep_percent_{suffix}"] == 25.0
+        assert history[f"average_awakening_count_{suffix}"] == 0.0
+        assert history[f"cumulative_sleep_debt_{suffix}"] == 3600
+        assert history[f"bedtime_consistency_{suffix}"] == 15.0
+        assert history[f"wake_time_consistency_{suffix}"] == 15.0
+
+
+def test_hypnogram_derives_awakenings_and_longest_run() -> None:
+    """Only actual sleep-to-awake transitions split uninterrupted sleep."""
+    report = {
+        "date": "2026-07-12",
+        "sessions": [
+            {
+                "total_sleep_duration": 300,
+                "in_bed_duration": 450,
+                "awake_duration": 150,
+                "sleep_latency": 50,
+                "hypnogram": {
+                    "raw_hypnogram_segment_count": 6,
+                    "segments": [
+                        {"start": 0, "end": 50, "stage": "AWAKE"},
+                        {"start": 50, "end": 150, "stage": "LIGHT_SLEEP"},
+                        {"start": 150, "end": 250, "stage": "REM_SLEEP"},
+                        {"start": 250, "end": 300, "stage": "AWAKE"},
+                        {"start": 300, "end": 400, "stage": "DEEP_SLEEP"},
+                        {"start": 450, "end": 440, "stage": "AWAKE"},
+                    ],
+                },
+            }
+        ],
+    }
+
+    summary = summarize_sleep_report(report)
+    assert summary["awakening_count"] == 1
+    assert summary["longest_uninterrupted_sleep_duration"] == 200
+
+
+def test_undefined_percentages_and_malformed_shapes_are_safe() -> None:
+    """Partial API payloads never cause divide-by-zero or shape failures."""
+    summary = summarize_sleep_report(
+        {
+            "date": "not-a-date",
+            "sessions": [{"hypnogram": {"segments": "not-a-list"}}, "bad"],
+        }
+    )
+
+    assert summary["date"] is None
+    assert summary["session_count"] == 1
+    assert summary["sleep_efficiency_percent"] is None
+    assert summary["sleep_goal_percent"] == 0.0
+    assert summary["awakening_count"] == 0
+    assert summarize_sleep_history([{"date": "not-a-date"}]) == {}
+
+
+def test_clock_consistency_wraps_across_midnight() -> None:
+    """23:50 and 00:10 are ten minutes from their circular mean."""
+    reports = [
+        {
+            "date": f"2026-07-{day:02d}",
+            "sessions": [
+                {
+                    "enter_bed_time": entered,
+                    "exit_bed_time": exited,
+                    "total_sleep_duration": 3600,
+                }
+            ],
+        }
+        for day, entered, exited in (
+            (10, "2026-07-09T23:50:00+00:00", "2026-07-10T07:50:00+00:00"),
+            (11, "2026-07-11T00:10:00+00:00", "2026-07-11T08:10:00+00:00"),
+        )
+    ]
+
+    history = summarize_sleep_history(reports)
+    assert history["bedtime_consistency_7d"] == pytest.approx(10.0)
+    assert history["wake_time_consistency_7d"] == pytest.approx(10.0)
 
 
 def test_missing_report_returns_empty_summary() -> None:

--- a/tests/test_sleepme.py
+++ b/tests/test_sleepme.py
@@ -9,6 +9,7 @@ Patches SleepMeAPI at the call boundary so we exercise the wrapper's:
 from __future__ import annotations
 
 from collections.abc import Generator
+from datetime import date
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -92,3 +93,41 @@ async def test_get_device_status_happy(client: SleepMeClient) -> None:
     client.api.api_request.return_value = payload
     result = await client.get_device_status()
     assert result == payload
+
+
+async def test_get_sleep_reports_happy(client: SleepMeClient) -> None:
+    """Sleep reports use the documented account-scoped query parameters."""
+    reports = [{"date": "2026-07-13", "sessions": []}]
+    client.api.api_request.return_value = {"reports": reports}
+
+    result = await client.get_sleep_reports(
+        start_date=date(2026, 7, 13),
+        days_back=6,
+        time_zone="Europe/Budapest",
+    )
+
+    assert result == reports
+    call = client.api.api_request.call_args
+    assert call.args == ("GET", "sleep-reports")
+    assert call.kwargs["params"] == {
+        "start_date": "2026-07-13",
+        "days_back": 6,
+        "time_zone": "Europe/Budapest",
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [[], {}, {"reports": {}}, {"reports": ["not-a-report"]}],
+)
+async def test_get_sleep_reports_rejects_bad_shapes(
+    client: SleepMeClient, payload: object
+) -> None:
+    """Malformed report responses fail closed instead of poisoning entities."""
+    client.api.api_request.return_value = payload
+    with pytest.raises(ValueError, match="unexpected response"):
+        await client.get_sleep_reports(
+            start_date=date(2026, 7, 13),
+            days_back=6,
+            time_zone="Europe/Budapest",
+        )

--- a/tests/test_sleepme_api.py
+++ b/tests/test_sleepme_api.py
@@ -177,6 +177,23 @@ async def test_401_raises_auth_error_immediately(api: SleepMeAPI) -> None:
     assert mock_sleep.await_count == 0
 
 
+async def test_query_parameters_are_passed_to_httpx(api: SleepMeAPI) -> None:
+    """The transport passes sleep-report query parameters separately from URLs."""
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json = MagicMock(return_value={"reports": []})
+    api.client.request.return_value = response
+
+    params = {
+        "start_date": "2026-07-13",
+        "days_back": 6,
+        "time_zone": "Europe/Budapest",
+    }
+    await api.api_request("GET", "sleep-reports", params=params, retries=0)
+
+    assert api.client.request.await_args.kwargs["params"] == params
+
+
 async def test_compute_backoff_falls_back_when_no_retry_after() -> None:
     """Static computation: base * 2**(attempt-1)."""
     resp = _http_response(429)


### PR DESCRIPTION
## Summary

- recognize ST501NA Sleep Trackers and expose live connectivity, occupancy, bed temperature, room temperature, and humidity entities
- fetch 30 days of public sleep reports in API-sized windows on a separate 30-minute coordinator
- expose recorder-friendly direct report data plus HA-derived efficiency, WASO, stage/restorative percentages, awakenings, uninterrupted sleep, main/additional-session timing, sleep goal/debt, 7/30-day averages, and clock-time consistency
- normalize the public API's minute-based report durations and hypnogram offsets to Home Assistant seconds while leaving the raw response action lossless
- add a Tracker-only configurable 4–12 hour sleep target for transparent goal/debt calculations
- add a response-only `sleepme_thermostat.get_sleep_reports` action for lossless access to session IDs and every raw hypnogram segment
- keep live Tracker entities available during a transient report-endpoint outage while preserving reauthentication behavior
- keep raw health reports out of diagnostics and state attributes, with fabricated API-schema fixtures for tests
- ship five validated automation blueprints: occupancy actions, presence-aware Dock control with an occupied wake extension, return-to-bed adjustment, Warm Awake, and report-threshold alerts
- add a stock HA dashboard example and a direct-versus-derived feature/limitation reference
- route new entity/option names through HA translations; Spanish is maintained, complete native Hungarian is included, and all 65 HA frontend locales are tested to resolve native text or the English fallback
- preserve the existing domain and climate-device behavior while using the SleepMe integration display name

## Public API boundary

The live Sleepme developer API was used read-only to validate the ST501NA device-status and `/sleep-reports` response schemas. The current public response provides finalized sleep stages and durations, but it does not expose live sleep stages, heart rate, HRV, respiration, or Sleepme's proprietary Hiber-AI control signal. The new HA-only metrics and automations are therefore documented as transparent formulas/heuristics rather than vendor-equivalent claims.

## Validation

- `ruff check .`
- `ruff format --check custom_components tests`
- `mypy custom_components/sleepme_thermostat`
- `pytest --cov --cov-report=term-missing --cov-fail-under=80` — **101 passed**, **91.73% coverage**
- actual HA automation-engine behavior tests for all five blueprints, including occupied wake extension, Warm Awake, and incomplete-report suppression
- Hungarian has complete key parity across onboarding, reauthentication, errors, entities, options, and services; every remaining HA locale resolves native text or the English fallback
- clean Home Assistant 2026.5.2 container: Dock + Tracker setup, all 61 Tracker registry entities available, second-normalized duration entities, options form, and all five blueprints loaded
- independent Playwright runs using Fedora's standalone system Chromium 150: login, entity registry, options values, all five Blueprint UI entries, and the rendered Hungarian profile/Tracker entity/options UI passed with no SleepMe console errors
- JSON/YAML parsing and `git diff --check`

No development token, local credentials, or live response data is included in this branch.
